### PR TITLE
fix(velero): remove invalid excludedNamespaces from cluster-resources-weekly

### DIFF
--- a/infrastructure/velero/templates/schedules.yaml
+++ b/infrastructure/velero/templates/schedules.yaml
@@ -68,8 +68,6 @@ spec:
       - runtimeclasses
       - validatingwebhookconfigurations
       - mutatingwebhookconfigurations
-    excludedNamespaces:
-      - "*"
     storageLocation: default
     ttl: {{ .Values.velero.schedules.cluster.weekly.retention | default "2160h" }}
     snapshotVolumes: false


### PR DESCRIPTION
## Summary
Fixes #8. The `cluster-resources-weekly` Velero schedule emitted `excludedNamespaces: ["*"]`, which Velero 1.18.0 rejects at validation (`excludes list cannot contain '*'`). Every weekly run reached `FailedValidation` and produced **no backup** — a DR gap for cluster-scoped objects (CRDs, ClusterRoles/Bindings, StorageClasses, webhooks, etc.).

## Change
Removed the invalid `excludedNamespaces: ["*"]` block from `infrastructure/velero/templates/schedules.yaml`. `includeClusterResources: true` + `includedResources` (already restricted to cluster-scoped types) captures exactly those objects regardless of namespace, so no namespace filter is needed. No other schedule is touched.

## Verification
- `helm template` confirms the rendered Schedule no longer contains `excludedNamespaces: ["*"]`.
- After merge + ArgoCD sync, a one-off `velero backup create --from-schedule cluster-resources-weekly` will be triggered to confirm it reaches `Completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)