### PR TITLE
fix(prod-pg): wire extendedConfiguration passthrough to activate PG tuning

### DIFF
--- a/argocd/applications/templates/postgresql.yaml
+++ b/argocd/applications/templates/postgresql.yaml
@@ -67,6 +67,10 @@ spec:
           pgHbaConfiguration: |
             {{- .Values.postgresql.primary.pgHbaConfiguration | nindent 12 }}
           {{- end }}
+          {{- if and .Values.postgresql.primary .Values.postgresql.primary.extendedConfiguration }}
+          extendedConfiguration: |
+            {{- .Values.postgresql.primary.extendedConfiguration | nindent 12 }}
+          {{- end }}
           {{- if .Values.postgresql.podDisruptionBudget }}
           podDisruptionBudget:
             {{- toYaml .Values.postgresql.podDisruptionBudget | nindent 12 }}
@@ -91,6 +95,10 @@ spec:
           {{- if .Values.postgresql.readReplicas.resources }}
           resources:
             {{- toYaml .Values.postgresql.readReplicas.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.postgresql.readReplicas.extendedConfiguration }}
+          extendedConfiguration: |
+            {{- .Values.postgresql.readReplicas.extendedConfiguration | nindent 12 }}
           {{- end }}
           {{- if .Values.postgresql.podDisruptionBudget }}
           podDisruptionBudget:


### PR DESCRIPTION
## What

Adds a guarded `extendedConfiguration` passthrough to the PostgreSQL ArgoCD Application template (`argocd/applications/templates/postgresql.yaml`) for both `primary` and `readReplicas`.

## Why

The PG perf-tuning **values** already landed on `main` (in `f735f8b`, mixed into the release-bump commit) for `mycure-production.yaml`:

```
shared_buffers 128MB→2GB, work_mem 4MB→16MB, maintenance_work_mem 64MB→256MB,
effective_cache_size 4GB→5GB, random_page_cost 4→1.1, effective_io_concurrency 1→200
```

…but they're currently **inert** — the app template never passed `extendedConfiguration` to the Bitnami chart, so nothing renders. This PR wires that passthrough so the tuning actually applies.

Background: prod PG ran stock defaults for a 35 GB DB → **28% cache-hit ratio** and **~4 TB temp spill** while the Mongo→PG migrator full-scans the primary, starving hapihub-next and slowing the app for users.

## ⚠️ Merge impact

Merging makes ArgoCD render the new `postgresql.conf` → **PG primary + read replica restart**. hapihub-next reads the **primary**, so expect a brief (seconds) DB blip → **merge off-peak**. Because the postgresql Application uses an inline `valuesObject` baked by the parent app-of-apps, you may need to **hard-refresh the parent root app** for it to re-render. Fully reversible via revert.

## Scope / safety

- Backward-compatible: `{{- if … }}`-guarded, no-op for demo/preprod (they don't set the value).
- $0 cost — config only, fits inside the existing 8 Gi pod limit; no node/storage/limit changes.

## Follow-up

CPU oversubscription (primary + replica co-located on a 2-vCPU node at 103%) is **not** fixable by tuning — tracked in mycurelabs/monobase-infra#12 (node separation, planned maintenance).
