### PR TITLE
fix(prod/database-secrets): gate minio-credentials ExternalSecret on minio.enabled (#2)

### DIFF
--- a/argocd/applications/templates/database-secrets.yaml
+++ b/argocd/applications/templates/database-secrets.yaml
@@ -29,6 +29,10 @@ spec:
           domain: {{ .Values.global.domain }}
           environment: {{ .Values.global.environment }}
           secretPrefix: {{ .Values.global.secretPrefix | default "" | quote }}
+        # Forward minio.enabled so the chart can skip the minio-credentials
+        # ExternalSecret where MinIO is disabled (e.g. prod uses GCS, no GCP key).
+        minio:
+          enabled: {{ if .Values.minio }}{{ .Values.minio.enabled | default false }}{{ else }}false{{ end }}
 
   destination:
     server: https://kubernetes.default.svc

--- a/charts/database-secrets/templates/minio-externalsecret.yaml
+++ b/charts/database-secrets/templates/minio-externalsecret.yaml
@@ -1,7 +1,10 @@
 # MinIO ExternalSecret
 # Syncs MinIO credentials from GCP Secret Manager to Kubernetes
 # Used by: minio chart (Bitnami), API, HapiHub
-
+# Only rendered when MinIO is enabled — prod uses GCS (minio.enabled: false), so
+# the {prefix}-minio-root-* GCP keys don't exist there and a SecretSyncedError
+# would otherwise mark dependent ArgoCD apps Degraded.
+{{- if .Values.minio.enabled }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -40,3 +43,4 @@ spec:
     - secretKey: minioRootPassword
       remoteRef:
         key: {{ .Values.global.secretPrefix | default .Values.global.namespace }}-minio-root-password
+{{- end }}

--- a/charts/database-secrets/values.yaml
+++ b/charts/database-secrets/values.yaml
@@ -11,3 +11,9 @@ global:
   # for ephemeral prod-mirror envs that restore real data and must decrypt it
   # with the original credentials.
   secretPrefix: ""
+
+# MinIO credentials ExternalSecret toggle. Forwarded from the deployment values
+# by the database-secrets ArgoCD Application. Default off: the secret is only
+# synced where MinIO is actually enabled (preprod/demo); prod uses GCS.
+minio:
+  enabled: false


### PR DESCRIPTION
## What
Render the `minio-credentials` ExternalSecret only where MinIO is enabled.

## Why (#2)
MinIO is disabled in production (`minio.enabled: false` — prod uses GCS). The unconditional `minio-credentials` ExternalSecret targets `{prefix}-minio-root-*` GCP keys that aren't used there, so it fails with `SecretSyncedError` and has marked **3 ArgoCD apps** (`*-database-secrets`, `-hapihub`, `-mycure-myaccount`) Degraded since 2025-11-18. Cosmetic, but noisy.

## How
- `argocd/applications/templates/database-secrets.yaml` — forward `minio.enabled` into the chart's `valuesObject` (the Application previously passed only `global:`, so a template-only gate would have been permanently false and wrongly dropped the secret everywhere).
- `charts/database-secrets/templates/minio-externalsecret.yaml` — wrap the ExternalSecret in `{{- if .Values.minio.enabled }}`.
- `charts/database-secrets/values.yaml` — add default-off `minio.enabled`.

## Effect
- **prod** (`minio.enabled: false`) → secret no longer rendered → ArgoCD prunes it (`prune: true`) → apps Healthy.
- **preprod/demo** (`minio.enabled: true`) → unchanged, secret still synced.

## Verification
- `helm template charts/database-secrets --set minio.enabled=false` → no minio ExternalSecret; `=true` → present. mongodb/postgresql/valkey unaffected.
- Rendered app-of-apps with prod/preprod/demo values: `database-secrets` Application `valuesObject` shows `minio.enabled` `false`/`true`/`true` respectively. `helm lint` clean.
- **Post-merge (needs in-cluster confirm before closing #2):** preprod `minio` ExternalSecret still `SecretSynced` (no regression); prod `minio-credentials` gone; the 3 apps report Healthy.

Refs #2 — left open for in-cluster verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)