### PR TITLE
fix(preprod,demo/mailpit): disable public web UI route — unauthenticated PHI exposure (#5)

### DIFF
--- a/values/deployments/mycure-demo.yaml
+++ b/values/deployments/mycure-demo.yaml
@@ -309,7 +309,12 @@ mailpit:
       cpu: 100m
       memory: 64Mi
   gateway:
-    enabled: true
+    # Public web UI route disabled (#5): an unauthenticated HTTPRoute exposes every
+    # captured email (reset tokens / OTPs / PHI) to anyone with the URL. Access the
+    # inbox via: kubectl port-forward svc/mailpit-http 8025:80
+    # (the route attaches to nginx-shared-gateway; re-enable behind gateway auth —
+    # e.g. basic-auth — if a public URL is ever needed).
+    enabled: false
     hostname: "mail.demo.localfirsthealth.com"
 
 # ===== DISABLED COMPONENTS (enabled:false stubs required by app-of-apps templates) =====

--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -787,7 +787,12 @@ mailpit:
       memory: 64Mi
 
   gateway:
-    enabled: true
+    # Public web UI route disabled (#5): preprod runs on cloned-prod data, and an
+    # unauthenticated HTTPRoute leaked reset tokens / OTPs / PHI to anyone with the
+    # URL. Access the inbox via: kubectl port-forward svc/mailpit-http 8025:80
+    # (the route attaches to nginx-shared-gateway; re-enable behind gateway auth —
+    # e.g. basic-auth — if a public URL is ever needed).
+    enabled: false
     hostname: "mail.preprod.localfirsthealth.com"
 
 # ===== P2P SYNC: Cadence =====


### PR DESCRIPTION
## What
Stop publishing the mailpit web UI on a public Gateway HTTPRoute in preprod and demo.

## Why (#5)
The mailpit UI was exposed at `mail.preprod.localfirsthealth.com` / `mail.demo.localfirsthealth.com` with **no auth**. Preprod runs on **cloned-prod data**, so anyone with the URL could read every captured email — password-reset links/tokens, magic links, 2FA OTPs, and any PHI/PII in transactional mail. No basic-auth/SecurityPolicy pattern exists in the repo today, so the chosen fix is to remove the public surface.

## How
Set `mailpit.gateway.enabled: false` in `values/deployments/mycure-preprod.yaml` and `values/deployments/mycure-demo.yaml`. The HTTPRoute is gated by `and .Values.enabled .Values.gateway.enabled`, so it stops rendering. The mailpit Deployment + Services (SMTP capture + internal web) stay — outbound app email is still captured in-cluster.

(For reference: the mailpit HTTPRoute attaches to `nginx-shared-gateway` in `nginx-gateway-system`, not Envoy — these envs route through NGINX Gateway Fabric.)

## Access after merge
```
kubectl port-forward -n mycure-preprod svc/mailpit-http 8025:80
# then browse http://localhost:8025
```
(If a public URL is wanted later, re-enable behind gateway auth — e.g. basic-auth — fronted by an ExternalSecret-synced credential.)

## Verification
- `helm template charts/mailpit --set enabled=true --set gateway.enabled=false` → Deployment + Services, **no** HTTPRoute/BackendTrafficPolicy. Control (`gateway.enabled=true`) renders the HTTPRoute. `helm lint` clean.
- **Post-merge (needs confirm before closing #5):** both hostnames no longer route; port-forward reaches the UI; a test email still lands in the inbox.

Refs #5 — left open for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)