### PR TITLE
chore(preprod): bump cadence 0.5.19 → 0.5.20 (change-log trim)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -801,7 +801,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.19"
+    tag: "0.5.20"
     pullPolicy: Always
 
   replicaCount: 1


### PR DESCRIPTION
## Summary

Bumps preprod cadence to **0.5.20** to roll out periodic change-log trim — durable fix for the unbounded Valkey AOF growth that caused the 2026-06-15 production outage.

- Code PR: mycurelabs/monobase-mycure#1545 (merged)
- Tracking issue: mycurelabs/monobase-mycure#1543
- Image: `ghcr.io/mycurelabs/cadence:0.5.20` (pushed 2026-06-16)

## What changes at runtime

- Cadence spawns a periodic trim task (5-min interval default) that deletes change-log entries below a watermark-guarded safe floor.
- Three safety layers: hard floor (always keep last 100k seqs), watermark guard (never trim past a connected/recent peer), below-trim-floor handshake (any reconnecting peer with `since_seq < min_seq` is re-routed to the primary-reader snapshot path).
- All 5 trim params (`CADENCE_CHANGELOG_TRIM_INTERVAL_SECS`, `_MIN_RETAINED_COUNT`, `_PEER_STALENESS_MS`, `_TRIM_BATCH_SIZE`, `_RETENTION_MS`) are env-overridable for hot-tuning without a code deploy. Kill-switch: set interval to 0.

## Baseline (captured 2026-06-16 pre-rollout)

| | preprod | production |
|---|---|---|
| cadence | 0.5.19 | 0.5.19 |
| Valkey AOF | 83 MB | 3.0 GB |
| Valkey RSS | 101 MB | 3.95 GB |
| PVC | 3 % of 3.9 GB | 10 % of 32 GB |

## Verification plan

- [ ] ArgoCD root-app sync re-renders the `cadence.image.tag` valuesObject (root-app pattern — child sync alone won't pick it up).
- [ ] Cadence pod restarts with the new image.
- [ ] Pod logs show periodic `changelog trim deleted=N trim_seq=M max_seq=K` at INFO over the next 30 min.
- [ ] `du -sh /data/appendonlydir/` on `valkey-primary-0` stays in the 80–200 MB band.
- [ ] No peer reconnect errors / no spike in `cadence.catchup.failed` (if metric exists; otherwise log scan).
- [ ] 7-day soak before bumping production (exercises the 7-day stale-peer eviction path).

## Risk

- **Trim too aggressive** → mitigated by three safety layers above.
- **First-tick I/O burst** → bounded by `change_log_trim_batch_size=10_000` per tick; preprod's 83 MB AOF is well below where this matters.
- **Schema migration** (new `updated_at_ms` column on `peer_watermarks` SQLite table) — handled idempotently via `ALTER TABLE ADD COLUMN` with duplicate-column error suppression. Valkey side just adds a new `watermarks:meta` hash; no migration needed.