### PR TITLE
chore(production): bump cadence 0.5.19 → 0.5.20 (change-log trim)

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1071,7 +1071,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.19"
+    tag: "0.5.20"
     pullPolicy: Always
 
   replicaCount: 1


### PR DESCRIPTION
## Summary

Promotes cadence **0.5.20** (change-log trim) to production after a clean 6-day preprod soak.

- Code PR: mycurelabs/monobase-mycure#1545 (merged 2026-06-16)
- Preprod rollout: monobase-infra#16 (merged 2026-06-16)
- Tracking issue: mycurelabs/monobase-mycure#1543

## Preprod soak result (6 days)

| | Day 0 | Day 6 |
|---|---|---|
| Cadence restarts | 0 | **0** |
| Valkey AOF | 90 MB peak | **44 MB** (BGREWRITEAOF compacted) |
| Valkey RSS | 102 MB peak | **45 MB** |
| `changes:by_seq` ZCARD | 226k | **100k** (hard floor) |
| min seq | 1 | 153675 |
| max seq | 236446 | 253674 |

ZCARD is pinned at exactly the `change_log_min_retained_count` (100_000) default, with trim keeping pace with new writes. Steady state reached.

## Production rollout expectations

Backlog is much larger than preprod was: **~8M change-log entries / 3.0 GB AOF**.

- First-tick cleanup is bounded by `change_log_trim_batch_size=10_000` per 5-min tick → roughly **3 days** to converge on the 100k floor.
- AOF will grow briefly from the deletion records, then compact via Bitnami's default BGREWRITEAOF trigger (100% growth from last rewrite).
- If the cleanup pace looks too slow, the runtime supports an env-side override: `CADENCE_CHANGELOG_TRIM_BATCH_SIZE=50000` will quadruple throughput without a redeploy.

## Verification plan

- [ ] ArgoCD root-app sync re-renders the `cadence.image.tag` valuesObject
- [ ] Cadence pod restarts with the new image, no crashloop
- [ ] Periodic `changelog trim deleted=N trim_seq=M max_seq=K` log lines start ~5 min after boot
- [ ] `du -sh /data/appendonlydir/` on `valkey-primary-0` starts shrinking (after first BGREWRITEAOF)
- [ ] `ZCARD cadence:<hash>:changes:by_seq` converges on 100000 over ~3 days
- [ ] No peer reconnect errors / catchup failures

## Risk

Same three-layer safety as preprod:

1. **Hard floor** — never trim past `max_seq - 100_000`
2. **Watermark guard** — never trim past a connected/recent peer's replay position
3. **Below-trim-floor handshake** — any peer reconnecting with `since_seq < min_seq` is re-routed to the primary-reader snapshot path

If any layer were broken, preprod would have shown peer-side errors during the 6-day soak. None observed.