### PR TITLE
chore(production): PAUSE cadence (replicaCount=0) — 0.5.20 trim insufficient

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1074,7 +1074,11 @@ cadence:
     tag: "0.5.20"
     pullPolicy: Always
 
-  replicaCount: 1
+  # 2026-06-22 OUTAGE PAUSE — scaled to 0 until cadence 0.5.21 ships with
+  # memory-aware trim + NOSCRIPT-safe Lua. 0.5.20's count-based trim cannot
+  # keep up with the baseline-scan write storm (~50k writes/sec → valkey OOM
+  # in 2-3 min). Restore to 1 after 0.5.21 deploys. See monobase-mycure#1543.
+  replicaCount: 0
 
   # Resources sized to the empirically-observed memory floor (2026-06-10
   # incident, monobase-infra#10). After §A.2/§B/§D/§E shipped in 0.5.14-0.5.17


### PR DESCRIPTION
## Summary

**OUTAGE PAUSE.** Production cadence 0.5.20 is crashlooping valkey because of two showstopper issues surfaced by the rollout. Setting `replicaCount: 0` to stop the write storm. Clients will be without sync until 0.5.21 ships.

## Two bugs found in 0.5.20

### 1. Trim cannot keep pace with baseline-scan write storm

PgPollWatcher emits ~50k change-log writes/sec on boot while scanning the primary DB. Trim's hard cap is `change_log_trim_batch_size / change_log_trim_interval_secs` writes/sec — at defaults that's 10k / 300s = ~33/sec. Even with env overrides set to `BATCH_SIZE=1_000_000` and `INTERVAL_SECS=30`, that's 33k/sec — still slower than the write rate.

Result: valkey memory grows monotonically. With container limit 4 GiB and base RDB at ~3.7 GiB, OOM hits within 2-3 minutes. After OOM:

### 2. NOSCRIPT after every valkey restart

When valkey restarts (OOM or otherwise), its script cache is wiped. Cadence's `evalsha` uses a SHA cached at boot, which is no longer registered:

```
WARN cadence::runtime: changelog trim failed error=Unknown Error: NOSCRIPT No matching script. trim_seq=199803
```

This silently breaks trim until cadence itself restarts. My own bug in 0.5.20 — I used `evalsha` without `SCRIPT EXISTS` check or `EVAL` fallback.

## Architectural root cause

Already named in research: **cadence is valkey-memory-blind**. Trim is count-based, not pressure-based; watcher has no backpressure when valkey is saturated. The 0.5.21 follow-up will land:

- Cadence polls valkey `INFO memory` each trim tick; computes `pressure_ratio = used_memory / maxmemory`
- Watcher applies backpressure (pause/throttle) when `pressure_ratio > threshold`
- Trim Lua uses `SCRIPT EXISTS` check + `EVAL` fallback to recover from `NOSCRIPT`
- Set valkey `maxmemory` + `noeviction` in helm so OOM is observable from cadence's `OOM command not allowed` errors, not as k8s OOMKill (clean-shutdown signal vs SIGKILL)
- New env-overridable threshold knobs

## What this PR does

Sets `cadence.replicaCount: 0` in `mycure-production.yaml`. Comment explains the why for future readers. Restore to 1 after 0.5.21 deploys to GHCR.

## Verification

- [ ] Cadence pod terminates within ~30 sec of ArgoCD sync
- [ ] Valkey crash loop stops (no more incoming writes)
- [ ] Re-flush valkey AOF dir via debug pod (so it boots empty for 0.5.21)
- [ ] Clients show sync-stopped state — accepted degradation
- [ ] Open follow-up PR for cadence 0.5.21 with memory-aware trim