### PR TITLE
chore(infra): valkey maxmemory + noeviction for cadence 0.5.21

### DIFF
--- a/argocd/applications/templates/valkey.yaml
+++ b/argocd/applications/templates/valkey.yaml
@@ -44,6 +44,9 @@ spec:
           resourcesPreset: "none"
           resources: {{ .Values.valkey.master.resources | toYaml | nindent 12 }}
           {{- end }}
+          {{- if .Values.valkey.master.extraFlags }}
+          extraFlags: {{ .Values.valkey.master.extraFlags | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.global.nodePool }}
           nodeSelector:
             node-pool: {{ .Values.global.nodePool }}

--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -707,6 +707,14 @@ valkey:
       limits:
         cpu: 500m
         memory: 2Gi
+    # Cap at 75% of container memory limit (1.5 GiB of 2 GiB). Pairs with
+    # cadence 0.5.21's memory-aware trim: when valkey returns OOM,
+    # append_change retries with backoff and the trim task escalates.
+    extraFlags:
+      - "--maxmemory"
+      - "1610612736"  # 1.5 GiB
+      - "--maxmemory-policy"
+      - "noeviction"
 
 # ===== STORAGE: MinIO Object Storage =====
 minio:

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -986,6 +986,20 @@ valkey:
       limits:
         cpu: 1000m
         memory: 4Gi
+    # 2026-06-22: cap valkey at 80% of container limit (3.2 GiB of 4 GiB)
+    # with `noeviction`. Once cadence 0.5.21 is wired up, hitting this cap
+    # produces `OOM command not allowed when used_memory > 'maxmemory'` on
+    # writes — which cadence catches in `append_change`, retries with
+    # backoff, and uses to drive the memory-aware trim task's emergency
+    # mode. Without this cap, valkey grows unbounded inside the container
+    # until the k8s SIGKILL (exitCode 137) kicks in mid-AOF-replay and
+    # we cycle into LOAD→OOM→LOAD. With this cap, OOM becomes app-
+    # observable and recoverable. See cadence 0.5.21 + monobase-mycure#1543.
+    extraFlags:
+      - "--maxmemory"
+      - "3221225472"  # 3 GiB (75% of 4 GiB limit; gives ~1 GiB AOF-rewrite headroom)
+      - "--maxmemory-policy"
+      - "noeviction"
 
 # ===== STORAGE: MinIO Object Storage =====
 minio:

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1074,7 +1074,11 @@ cadence:
     tag: "0.5.20"
     pullPolicy: Always
 
-  replicaCount: 1
+  # 2026-06-22 OUTAGE PAUSE — scaled to 0 until cadence 0.5.21 ships with
+  # memory-aware trim + NOSCRIPT-safe Lua. 0.5.20's count-based trim cannot
+  # keep up with the baseline-scan write storm (~50k writes/sec → valkey OOM
+  # in 2-3 min). Restore to 1 after 0.5.21 deploys. See monobase-mycure#1543.
+  replicaCount: 0
 
   # Resources sized to the empirically-observed memory floor (2026-06-10
   # incident, monobase-infra#10). After §A.2/§B/§D/§E shipped in 0.5.14-0.5.17


### PR DESCRIPTION
## Summary

Three-part infra change that pairs with cadence 0.5.21 (memory-aware trim) to recover from the 2026-06-22 production rollout incident.

- Cadence 0.5.21 PR: mycurelabs/monobase-mycure#1876
- Tracking issue: mycurelabs/monobase-mycure#1543

## What changes

1. **`argocd/applications/templates/valkey.yaml`** — forward `valkey.master.extraFlags` from deployment values to the chart's `primary.extraFlags`. Previously there was no way to set valkey CLI flags from IaC.

2. **`mycure-production.yaml`** — `--maxmemory 3221225472` (3 GiB, 75% of 4 GiB container limit) + `--maxmemory-policy noeviction`.

3. **`mycure-preprod.yaml`** — `--maxmemory 1610612736` (1.5 GiB, 75% of 2 GiB container limit) + `--maxmemory-policy noeviction`.

## How this interacts with cadence 0.5.21

Before:
- Valkey grows unbounded inside container (no maxmemory)
- k8s SIGKILLs valkey at the container limit (exitCode 137) — typically mid-AOF-replay
- Pod restarts, LOADs the dataset, hits the limit again → infinite loop

After:
- Valkey reports `OOM command not allowed` to cadence when writes would push past 75% of container
- Cadence 0.5.21's `append_change` catches it, retries with backoff (~1.5 s budget)
- Cadence's trim task polls `INFO memory` and sees `pressure_ratio >= 0.75` → escalates: drops watermark floor, raises batch size 10×, logs WARN
- ~1 GiB headroom between maxmemory and container limit absorbs AOF-rewrite transient spikes

## Verification

- [ ] Cadence 0.5.21 merges + image lands in GHCR
- [ ] This PR merges
- [ ] ArgoCD root-app sync re-renders valuesObject with extraFlags
- [ ] Valkey pod restarts with `--maxmemory` visible in `kubectl exec ... -- redis-cli CONFIG GET maxmemory`
- [ ] Cadence 0.5.21 boots, baseline-scan runs, valkey memory plateaus below 3 GiB instead of climbing to OOM
- [ ] Restore `cadence.replicaCount: 1` in mycure-production.yaml (sibling follow-up PR)

## Risk

- **maxmemory too tight + AOF rewrite spike.** Mitigated by 25% headroom (3 GiB cap vs 4 GiB container).
- **noeviction blocks writes when full.** That's the intended signal. Without cadence 0.5.21 deployed, writes would fail outright — only land this PR after the cadence PR is in GHCR.
- **Template change affects demo too.** Demo doesn't set `master.extraFlags` so the `{{- if }}` guard keeps it a no-op there.