### PR TITLE
chore(production): unpause cadence + bump to 0.5.21

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -809,7 +809,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.20"
+    tag: "0.5.21"
     pullPolicy: Always
 
   replicaCount: 1

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1085,14 +1085,10 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.20"
+    tag: "0.5.21"
     pullPolicy: Always
 
-  # 2026-06-22 OUTAGE PAUSE — scaled to 0 until cadence 0.5.21 ships with
-  # memory-aware trim + NOSCRIPT-safe Lua. 0.5.20's count-based trim cannot
-  # keep up with the baseline-scan write storm (~50k writes/sec → valkey OOM
-  # in 2-3 min). Restore to 1 after 0.5.21 deploys. See monobase-mycure#1543.
-  replicaCount: 0
+  replicaCount: 1
 
   # Resources sized to the empirically-observed memory floor (2026-06-10
   # incident, monobase-infra#10). After §A.2/§B/§D/§E shipped in 0.5.14-0.5.17


### PR DESCRIPTION
## Summary

Unpause cadence in production now that the architectural fixes are in:

- cadence 0.5.21: mycurelabs/monobase-mycure#1876 (merged, image `ghcr.io/mycurelabs/cadence:0.5.21` pushed at 2026-06-22T08:09:48Z)
- valkey maxmemory + noeviction: monobase-infra#19 (merged)

This PR:
1. Bumps preprod cadence 0.5.20 → 0.5.21
2. Bumps production cadence 0.5.20 → 0.5.21
3. Restores production `cadence.replicaCount: 0 → 1` (the OUTAGE PAUSE from #18)

## What to expect after ArgoCD sync

Production cadence pod boots, runs PgPollWatcher baseline scan (~50k writes/sec for 1-3 min), and writes change-log entries into valkey.

- **Valkey enforces maxmemory at 3 GiB** (was unbounded → SIGKILL at 4 GiB container limit)
- **OOM is now app-observable**: when the write storm pushes valkey toward the cap, `append_change` gets `OOM command not allowed when used_memory > 'maxmemory'`
- **Cadence's `append_change` retries** with 100/200/300/400/500 ms backoff (~1.5 s total budget)
- **Trim task escalates** when `used / maxmemory >= 0.75`:
  - Drops the watermark-floor guard
  - Drops the hard floor (trim_seq = max_seq - 1)
  - Raises batch size to 100k (10× normal)
  - Logs WARN: `changelog trim (EMERGENCY — pressure above threshold)`
- **Stale peers** that fall below `min_seq` after the emergency trim re-route through the below-trim-floor handshake → primary-reader snapshot path on reconnect (correctness backstop)

Steady state: valkey RSS plateaus well under 3 GiB, no SIGKILLs, sync resumed.

## Verification (post-merge)

- [ ] Cadence pod `kubectl get pod -n mycure-production -l app.kubernetes.io/name=cadence`: READY 1/1, RESTARTS 0
- [ ] Valkey pod `kubectl get pod valkey-primary-0 -n mycure-production`: 0 new restarts
- [ ] `kubectl exec valkey-primary-0 -- redis-cli CONFIG GET maxmemory` reports `3221225472`
- [ ] Cadence logs over 5+ min show periodic `changelog trim deleted=N trim_seq=M max_seq=K` AT INFO (normal mode) or WARN (emergency, expected briefly during baseline scan)
- [ ] Valkey memory `INFO memory | grep used_memory_human` stays under 3 GiB
- [ ] No `OOM command not allowed` errors in cadence logs (or, if present, followed by successful retries)
- [ ] Clients begin reconnecting and showing sync activity

## Rollback

If anything goes wrong: revert this PR (re-pause via replicaCount=0). The 0.5.20 → 0.5.21 image is forward-compatible; rolling back the image is also safe.