### PR TITLE
chore(cadence): blacklist activity-logs to unstall PgPollWatcher

### DIFF
--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -150,6 +150,11 @@ cadenceConfig:
   collectionsBlacklist:
     - "--drizzle-migrations"
     - "-migration-checkpoints"
+    # 2026-06-22: million-row low-value table; baseline scan grinds for hours
+    # and blocks the watcher's sequential per-table loop, starving every other
+    # collection. Skip entirely until pg_poll gets per-table parallelism or
+    # timeouts. See monobase-mycure#1543 follow-up + memory project_cadence_0521_rollout_state.
+    - "activity-logs"
   # Per-collection sync priority (higher = sent first during catch-up).
   # "*" is the default for unlisted collections. Mirror of
   # services/hapihub/cadence.yml in monobase-mycure — keep in sync.


### PR DESCRIPTION
## Summary

Adds `activity-logs` to the cadence helm chart's `collectionsBlacklist`. Unstalls the production `PgPollWatcher` after the 0.5.21 rollout.

## Why

Production observation (2026-06-22): cadence 0.5.21 pod is healthy (no crashloop, no OOM, no NOSCRIPT) but its watcher reproducibly stalls after scanning the first 6-7 alphabetical tables (`account` → `action-codes`). Next alphabetically is `activity-logs` — a multi-million-row table.

`services/cadence/src/watcher/pg_poll.rs:535-556` iterates collections **sequentially** (`for collection in &collections`). No per-table timeout. No parallelism. No yield. activity-logs's baseline cursor loop (1000 rows/fetch) takes hours; meanwhile every other table waits.

The codebase already calls activity-logs "low-value" (`src/sync.rs:1053`, `src/config.rs:153,157`). This commit makes that priority decision absolute.

## What changes at runtime

- `services/cadence/src/config.rs::resolve_wildcard_pg` (lines 696, 741) calls `is_blacklisted()` during wildcard table discovery. Blacklisted tables never enter `self.collections`. Watcher loop never sees them.
- Effect: cadence watcher skips activity-logs entirely. The remaining ~146 tables baseline-scan normally. Trim task gets a clean shot at the 4M-entry backlog. Sync is restored.

## Rollout

1. Admin-merge this PR.
2. Trigger root-app hard-refresh + sync on `mycure-production-root` (per [[reference_argocd_root_app_pattern]]).
3. Sync `mycure-production-cadence` child app.
4. New pod boots with updated configmap.

## Verification

- [ ] `kubectl logs -n mycure-production <pod> | grep -c 'PgPollWatcher: baseline scanned'` returns >100 (was 6).
- [ ] `redis-cli -a $PASS ZCARD cadence:3a9224d27fd2baba:changes:by_seq` grows above 4M.
- [ ] Within 5-10 min of pod boot, log shows `cadence::runtime: changelog trim deleted=...`.
- [ ] No `activity-logs` in any `PgPollWatcher` log line.

## Out of scope

- Proper per-table parallelism / timeouts in `pg_poll.rs` (separate code change).
- Re-enabling activity-logs sync through a low-priority background path (also separate).