### PR TITLE
chore(cadence): bump preprod + prod 0.5.21 → 0.5.22

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -809,7 +809,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.21"
+    tag: "0.5.22"
     pullPolicy: Always
 
   replicaCount: 1

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1085,7 +1085,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.21"
+    tag: "0.5.22"
     pullPolicy: Always
 
   replicaCount: 1


### PR DESCRIPTION
## Summary

Bumps cadence to **0.5.22** in both preprod and production. Sprint-0 hotfix for the production trim silent-failure surfaced on 2026-06-22.

- Code PR: mycurelabs/monobase-mycure#1916 (merged)
- Image: \`ghcr.io/mycurelabs/cadence:0.5.22\` (pushed 2026-06-23T02:23:06Z)

## What's new in 0.5.22

1. **Watermark staleness 7d → 24h** — fixes the bug where 4 long-stale peer watermarks at seq=95668 pinned trim across a max_seq of ~5M for the entire current pod's uptime.
2. **Structured trim observability** — one INFO per tick with `max_seq, hard_floor, safe_floor, trim_seq, active_peer_count, persisted_peer_count, persisted_pruned_count, deleted`. WARN on stale-pin and batch-full.
3. **Bounded incremental pg poll** — `(ts, id) > (last_ts, last_id) ORDER BY ts ASC, id ASC LIMIT 5000`. Prevents the silent-stall mode where one bulk-inserted table starves the rest of the watcher loop.
4. **30s timeout on pg_poll** — silences silent stalls.

## Verification

- [ ] Cadence pod restarts cleanly on 0.5.22
- [ ] Within one trim interval: structured \`changelog trim\` INFO line appears in logs
- [ ] Within 24h of deploy: \`HLEN cadence:<hash>:watermarks:meta\` drops (stale peers pruned from safe-floor calc)
- [ ] \`ZCARD cadence:<hash>:changes:by_seq\` starts to drop on prod
- [ ] No new pod restarts; no new \`OOM command not allowed\` errors

## Rollback

Revert this PR; the 0.5.21 → 0.5.22 changes are backward-compatible (wire protocol unchanged, config fields are additive, env overrides still work).