### PR TITLE
chore(cadence): bump preprod + prod 0.5.22 → 0.5.24; parallel-workers on preprod

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -809,8 +809,16 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.22"
+    tag: "0.5.24"
     pullPolicy: Always
+
+  # Phase 1a: per-collection watcher workers. Spawned as N independent
+  # tokio tasks (one per collection) so a slow PG poll on one table
+  # can't starve the rest. Default off in the chart; preprod soaks
+  # before flipping prod. See mycurelabs/monobase-mycure#1918.
+  env:
+    - name: CADENCE_PER_COLLECTION_WORKERS
+      value: "true"
 
   replicaCount: 1
 

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1085,7 +1085,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.22"
+    tag: "0.5.24"
     pullPolicy: Always
 
   replicaCount: 1


### PR DESCRIPTION
## Summary

Bumps cadence in both deployments to **0.5.24**. Preprod additionally enables `CADENCE_PER_COLLECTION_WORKERS=true` to start the Phase-1a soak (≥5 days per the plan) before flipping prod.

| Version | Phase | What ships |
|---|---|---|
| 0.5.23 | 1a | per-collection watcher workers behind feature flag + poll deadline (always on) |
| 0.5.24 | 2 | `ApplierTracker` DashMap → moka with 5-min TTL + 100k entry cap (closes REFACTOR.md §2.4 leak) |

## Why bump prod too

Both versions are backward-compatible additions when the new flag is off:
- 0.5.23's per-collection-workers default is `false` — same as 0.5.22 behavior
- 0.5.23's poll-deadline is pure addition (only fires on a real >60s hang, which today silently stalls forever)
- 0.5.24's moka swap is internal-only — public ApplierTracker API unchanged

Prod immediately benefits from the moka leak fix (no more unbounded tracker growth) and the poll-deadline visibility. The parallel-workers flag stays off on prod until preprod soak validates it.

## Verification

- [ ] Cadence pods restart cleanly on 0.5.24
- [ ] Preprod logs show `starting per-collection PG watcher workers (Phase 1)` at boot
- [ ] Preprod baseline scans complete for all ~146 tables within 10 min (vs serial mode's same-table-takes-hours when one is large)
- [ ] Preprod RSS doesn't aggregate beyond serial-mode baseline (per-task LRUs each capped at lru_capacity, but mostly small in practice)
- [ ] Prod RSS slowly flattens over 24h as the moka TTL evicts stale tracker entries that DashMap previously held forever
- [ ] No new restart causes

## Rollback

- Revert this PR → back to 0.5.22
- Or set `CADENCE_PER_COLLECTION_WORKERS=false` env on preprod via kubectl set env (live rollback, no image change)

Refs mycurelabs/monobase-mycure#1543, #1918, #1920.