### PR TITLE
feat(preprod): deploy medical-AI stack + Tailscale Ollama egress

### DIFF
--- a/argocd/applications/templates/medgemma-worker.yaml
+++ b/argocd/applications/templates/medgemma-worker.yaml
@@ -1,0 +1,42 @@
+{{- if (.Values.medgemmaWorker | default dict).enabled }}
+# ArgoCD Application: MedGemma Worker
+# Sync Wave 3 - Deploy after core services
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.global.namespace }}-medgemma-worker
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    path: charts/medgemma-worker
+    repoURL: {{ .Values.argocd.repoURL }}
+    targetRevision: {{ .Values.argocd.targetRevision | default "main" }}
+    helm:
+      releaseName: medgemma-worker
+      valuesObject:
+        {{- toYaml .Values.medgemmaWorker | nindent 8 }}
+        global: {{ .Values.global | toYaml | nindent 10 }}
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.global.namespace }}
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        maxDuration: 5m
+{{- end }}

--- a/argocd/applications/templates/medley.yaml
+++ b/argocd/applications/templates/medley.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.medley.enabled }}
+# ArgoCD Application: Medley AI Gateway
+# Sync Wave 3 - Deploy after core services
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.global.namespace }}-medley
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    path: charts/medley
+    repoURL: {{ .Values.argocd.repoURL }}
+    targetRevision: {{ .Values.argocd.targetRevision | default "main" }}
+    helm:
+      releaseName: medley
+      valuesObject:
+        {{- toYaml .Values.medley | nindent 8 }}
+        global: {{ .Values.global | toYaml | nindent 10 }}
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.global.namespace }}
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        maxDuration: 5m
+{{- end }}

--- a/argocd/applications/templates/medleyapp.yaml
+++ b/argocd/applications/templates/medleyapp.yaml
@@ -1,0 +1,42 @@
+{{- if (.Values.medleyapp | default dict).enabled }}
+# ArgoCD Application: MedleyApp Frontend
+# Sync Wave 3 - Deploy after core services
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.global.namespace }}-medleyapp
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    path: charts/medleyapp
+    repoURL: {{ .Values.argocd.repoURL }}
+    targetRevision: {{ .Values.argocd.targetRevision | default "main" }}
+    helm:
+      releaseName: medleyapp
+      valuesObject:
+        {{- toYaml .Values.medleyapp | nindent 8 }}
+        global: {{ .Values.global | toYaml | nindent 10 }}
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.global.namespace }}
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        maxDuration: 5m
+{{- end }}

--- a/argocd/applications/templates/openmed.yaml
+++ b/argocd/applications/templates/openmed.yaml
@@ -1,0 +1,42 @@
+{{- if (.Values.openmed | default dict).enabled }}
+# ArgoCD Application: OpenMed Model Server
+# Sync Wave 3 - Deploy after core services
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.global.namespace }}-openmed
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    path: charts/openmed
+    repoURL: {{ .Values.argocd.repoURL }}
+    targetRevision: {{ .Values.argocd.targetRevision | default "main" }}
+    helm:
+      releaseName: openmed
+      valuesObject:
+        {{- toYaml .Values.openmed | nindent 8 }}
+        global: {{ .Values.global | toYaml | nindent 10 }}
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.global.namespace }}
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        maxDuration: 5m
+{{- end }}

--- a/argocd/infrastructure/templates/ollama-egress.yaml
+++ b/argocd/infrastructure/templates/ollama-egress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ollamaEgress.enabled }}
+# ArgoCD Application: ollama-egress
+# Sync Wave 1 — Tailscale egress to the vanaheim workstation's Ollama (medical-AI inference backend).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ollama-egress
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: {{ .Values.argocd.repoURL }}
+    targetRevision: {{ .Values.argocd.targetRevision }}
+    path: charts/ollama-egress
+    helm:
+      releaseName: ollama-egress
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tailscale
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        maxDuration: 5m
+{{- end }}

--- a/charts/medgemma-worker/Chart.yaml
+++ b/charts/medgemma-worker/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: medgemma-worker
+description: MedGemma Worker - Medical vision AI inference worker (Hono/Bun backend)
+type: application
+version: 1.0.0
+appVersion: "0.1.0"
+keywords:
+  - medgemma
+  - ai
+  - medical
+  - vision
+  - hono
+  - bun
+home: https://github.com/mycurelabs/monobase-infra
+sources:
+  - https://github.com/mycurelabs/monobase
+maintainers:
+  - name: MyCure Labs
+    email: devops@mycure.md

--- a/charts/medgemma-worker/templates/NOTES.txt
+++ b/charts/medgemma-worker/templates/NOTES.txt
@@ -1,0 +1,47 @@
+{{- if .Values.enabled }}
+MedGemma Worker has been deployed!
+
+Chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+Release: {{ .Release.Name }}
+Namespace: {{ include "medgemma-worker.namespace" . }}
+
+Deployment Information:
+  - Replicas: {{ .Values.replicaCount }}
+  - Image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+  - Service: {{ include "medgemma-worker.fullname" . }}:{{ .Values.service.port }}
+
+Access Information:
+  Gateway is disabled (ClusterIP only). Use port-forward to access:
+  kubectl port-forward -n {{ include "medgemma-worker.namespace" . }} svc/{{ include "medgemma-worker.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+
+Monitoring:
+{{- if .Values.serviceMonitor.enabled }}
+  ServiceMonitor enabled - Metrics available at /metrics
+{{- else }}
+  ServiceMonitor disabled - Enable for production monitoring
+{{- end }}
+
+Security:
+{{- if .Values.networkPolicy.enabled }}
+  NetworkPolicy enabled
+  {{- if .Values.networkPolicy.ollamaEgress.enabled }}
+  Ollama egress allowed to {{ .Values.networkPolicy.ollamaEgress.cidr }}:{{ .Values.networkPolicy.ollamaEgress.port }}
+  {{- end }}
+{{- else }}
+  NetworkPolicy disabled - Enable for production
+{{- end }}
+
+Next Steps:
+  1. Verify pods are running:
+     kubectl get pods -n {{ include "medgemma-worker.namespace" . }} -l app.kubernetes.io/name={{ include "medgemma-worker.name" . }}
+
+  2. Check logs:
+     kubectl logs -n {{ include "medgemma-worker.namespace" . }} -l app.kubernetes.io/name={{ include "medgemma-worker.name" . }} --tail=50
+
+  3. Test health endpoint:
+     kubectl port-forward -n {{ include "medgemma-worker.namespace" . }} svc/{{ include "medgemma-worker.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+     curl http://localhost:{{ .Values.service.port }}/health
+
+{{- else }}
+MedGemma Worker is disabled (enabled: false)
+{{- end }}

--- a/charts/medgemma-worker/templates/_helpers.tpl
+++ b/charts/medgemma-worker/templates/_helpers.tpl
@@ -1,0 +1,131 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "medgemma-worker.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "medgemma-worker.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "medgemma-worker.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "medgemma-worker.labels" -}}
+helm.sh/chart: {{ include "medgemma-worker.chart" . }}
+{{ include "medgemma-worker.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: monobase
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "medgemma-worker.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "medgemma-worker.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "medgemma-worker.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "medgemma-worker.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Gateway hostname - defaults to medgemma-worker.{global.domain}
+*/}}
+{{- define "medgemma-worker.gateway.hostname" -}}
+{{- if .Values.gateway.hostname }}
+{{- .Values.gateway.hostname }}
+{{- else }}
+{{- printf "medgemma-worker.%s" .Values.global.domain }}
+{{- end }}
+{{- end }}
+
+{{/*
+Namespace - uses global.namespace or Release.Namespace
+*/}}
+{{- define "medgemma-worker.namespace" -}}
+{{- default .Release.Namespace .Values.global.namespace }}
+{{- end }}
+
+{{/*
+Gateway parent reference name
+*/}}
+{{- define "medgemma-worker.gateway.name" -}}
+{{- default "shared-gateway" .Values.global.gateway.name }}
+{{- end }}
+
+{{/*
+Gateway parent reference namespace
+*/}}
+{{- define "medgemma-worker.gateway.namespace" -}}
+{{- default "gateway-system" .Values.global.gateway.namespace }}
+{{- end }}
+
+{{/*
+StorageClass name - auto-detects based on provider
+*/}}
+{{- define "medgemma-worker.storageClass" -}}
+{{- if .Values.global.storage.className -}}
+{{- .Values.global.storage.className }}
+{{- else if eq .Values.global.storage.provider "longhorn" -}}
+longhorn
+{{- else if eq .Values.global.storage.provider "ebs-csi" -}}
+gp3
+{{- else if eq .Values.global.storage.provider "azure-disk" -}}
+managed-premium
+{{- else if eq .Values.global.storage.provider "gcp-pd" -}}
+pd-ssd
+{{- else if eq .Values.global.storage.provider "local-path" -}}
+local-path
+{{- else -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Node Pool - returns the effective node pool name (component-level or global)
+Returns empty string if disabled or not configured
+*/}}
+{{- define "medgemma-worker.nodePool" -}}
+{{- if hasKey .Values "nodePool" -}}
+  {{- if and .Values.nodePool (hasKey .Values.nodePool "enabled") (not .Values.nodePool.enabled) -}}
+    {{- /* Component explicitly disabled node pool */ -}}
+  {{- else if and .Values.nodePool .Values.nodePool.name -}}
+    {{- .Values.nodePool.name -}}
+  {{- else if and .Values.global .Values.global.nodePool -}}
+    {{- .Values.global.nodePool -}}
+  {{- end -}}
+{{- else if and .Values.global .Values.global.nodePool -}}
+  {{- .Values.global.nodePool -}}
+{{- end -}}
+{{- end -}}

--- a/charts/medgemma-worker/templates/configmap.yaml
+++ b/charts/medgemma-worker/templates/configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "medgemma-worker.fullname" . }}
+  namespace: {{ include "medgemma-worker.namespace" . }}
+  labels:
+    {{- include "medgemma-worker.labels" . | nindent 4 }}
+data:
+  NODE_ENV: {{ .Values.config.NODE_ENV | quote }}
+  LOG_LEVEL: {{ .Values.config.LOG_LEVEL | quote }}
+  PORT: {{ .Values.config.PORT | quote }}
+  {{- range $key, $value := .Values.config }}
+  {{- if not (has $key (list "NODE_ENV" "LOG_LEVEL" "PORT")) }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/medgemma-worker/templates/deployment.yaml
+++ b/charts/medgemma-worker/templates/deployment.yaml
@@ -1,0 +1,129 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "medgemma-worker.fullname" . }}
+  namespace: {{ include "medgemma-worker.namespace" . }}
+  labels:
+    {{- include "medgemma-worker.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "medgemma-worker.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "medgemma-worker.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "medgemma-worker.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.targetPort }}
+          protocol: TCP
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          {{- if .Values.livenessProbe.httpGet }}
+          httpGet:
+            path: {{ .Values.livenessProbe.httpGet.path }}
+            port: {{ .Values.livenessProbe.httpGet.port | default "http" }}
+          {{- end }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          {{- if .Values.readinessProbe.httpGet }}
+          httpGet:
+            path: {{ .Values.readinessProbe.httpGet.path }}
+            port: {{ .Values.readinessProbe.httpGet.port | default "http" }}
+          {{- end }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        env:
+        # Set HOME to /tmp to avoid permission denied errors when running as non-root
+        - name: HOME
+          value: "/tmp"
+        # Load from ConfigMap
+        - name: NODE_ENV
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "medgemma-worker.fullname" . }}
+              key: NODE_ENV
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "medgemma-worker.fullname" . }}
+              key: LOG_LEVEL
+        - name: PORT
+          value: "8940"
+        # Load secrets from External Secrets Operator
+        {{- if .Values.externalSecrets.enabled }}
+        {{- range .Values.externalSecrets.secrets }}
+        - name: {{ .secretKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "medgemma-worker.fullname" $ }}-secrets
+              key: {{ .secretKey }}
+        {{- end }}
+        {{- end }}
+        # Additional environment variables from config
+        {{- range $key, $value := .Values.config }}
+        {{- if not (has $key (list "NODE_ENV" "LOG_LEVEL" "PORT")) }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+      {{- $nodePool := include "medgemma-worker.nodePool" . -}}
+      {{- if or $nodePool .Values.nodeSelector }}
+      nodeSelector:
+        {{- if $nodePool }}
+        node-pool: {{ $nodePool }}
+        {{- end }}
+        {{- with .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or $nodePool .Values.tolerations }}
+      tolerations:
+        {{- if $nodePool }}
+        - key: "node-pool"
+          operator: "Equal"
+          value: {{ $nodePool | quote }}
+          effect: "NoSchedule"
+        {{- end }}
+        {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/charts/medgemma-worker/templates/externalsecret.yaml
+++ b/charts/medgemma-worker/templates/externalsecret.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.enabled .Values.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "medgemma-worker.fullname" . }}-secrets
+  namespace: {{ include "medgemma-worker.namespace" . }}
+  labels:
+    {{- include "medgemma-worker.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStore | default (printf "%s-secretstore" (include "medgemma-worker.namespace" .)) }}
+    kind: SecretStore
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | default "1h" }}
+  target:
+    name: {{ include "medgemma-worker.fullname" . }}-secrets
+    creationPolicy: Owner
+  data:
+    {{- range .Values.externalSecrets.secrets }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ .remoteKey }}
+        {{- if .property }}
+        property: {{ .property }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/medgemma-worker/templates/hpa.yaml
+++ b/charts/medgemma-worker/templates/hpa.yaml
@@ -1,0 +1,50 @@
+{{- if and .Values.enabled .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "medgemma-worker.fullname" . }}
+  namespace: {{ include "medgemma-worker.namespace" . }}
+  labels:
+    {{- include "medgemma-worker.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "medgemma-worker.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+      selectPolicy: Max
+{{- end }}

--- a/charts/medgemma-worker/templates/httproute.yaml
+++ b/charts/medgemma-worker/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.enabled .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "medgemma-worker.fullname" . }}
+  namespace: {{ include "medgemma-worker.namespace" . }}
+  labels:
+    {{- include "medgemma-worker.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "medgemma-worker.gateway.name" . }}
+      namespace: {{ include "medgemma-worker.gateway.namespace" . }}
+      sectionName: https  # Only attach to HTTPS listener
+      {{- if .Values.gateway.sectionName }}
+      # Override: {{ .Values.gateway.sectionName }}
+      {{- end }}
+  hostnames:
+    {{- if .Values.gateway.hostnames }}
+    {{- range .Values.gateway.hostnames }}
+    - {{ . }}
+    {{- end }}
+    {{- else }}
+    - {{ include "medgemma-worker.gateway.hostname" . }}
+    {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "medgemma-worker.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 1
+      {{- if .Values.gateway.filters }}
+      filters:
+        {{- toYaml .Values.gateway.filters | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/medgemma-worker/templates/networkpolicy.yaml
+++ b/charts/medgemma-worker/templates/networkpolicy.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.enabled .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "medgemma-worker.fullname" . }}
+  namespace: {{ include "medgemma-worker.namespace" . }}
+  labels:
+    {{- include "medgemma-worker.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "medgemma-worker.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- end }}
+  {{- if or .Values.networkPolicy.egress .Values.networkPolicy.ollamaEgress.enabled }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+    {{- if .Values.networkPolicy.ollamaEgress.enabled }}
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.networkPolicy.ollamaEgress.cidr }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.ollamaEgress.port }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/medgemma-worker/templates/pdb.yaml
+++ b/charts/medgemma-worker/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.enabled .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "medgemma-worker.fullname" . }}
+  namespace: {{ include "medgemma-worker.namespace" . }}
+  labels:
+    {{- include "medgemma-worker.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "medgemma-worker.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/medgemma-worker/templates/service.yaml
+++ b/charts/medgemma-worker/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "medgemma-worker.fullname" . }}
+  namespace: {{ include "medgemma-worker.namespace" . }}
+  labels:
+    {{- include "medgemma-worker.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "medgemma-worker.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/medgemma-worker/templates/serviceaccount.yaml
+++ b/charts/medgemma-worker/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.enabled .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "medgemma-worker.serviceAccountName" . }}
+  namespace: {{ include "medgemma-worker.namespace" . }}
+  labels:
+    {{- include "medgemma-worker.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/medgemma-worker/templates/servicemonitor.yaml
+++ b/charts/medgemma-worker/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.enabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "medgemma-worker.fullname" . }}
+  namespace: {{ include "medgemma-worker.namespace" . }}
+  labels:
+    {{- include "medgemma-worker.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "medgemma-worker.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | default "/metrics" }}
+      interval: {{ .Values.serviceMonitor.interval | default "30s" }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+{{- end }}

--- a/charts/medgemma-worker/values.yaml
+++ b/charts/medgemma-worker/values.yaml
@@ -1,0 +1,162 @@
+# Default values for MedGemma Worker chart
+# Override these values in values/deployments/*.yaml
+
+global:
+  domain: example.com
+  namespace: example-prod
+  environment: production
+  gateway:
+    name: shared-gateway
+    namespace: gateway-system
+  storage:
+    provider: ""
+    className: ""
+
+enabled: true
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/mycurelabs/medgemma-worker
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+
+service:
+  type: ClusterIP
+  port: 8940
+  targetPort: 8940
+  annotations: {}
+
+# Gateway: disabled — medgemma-worker is ClusterIP only, no public HTTPRoute
+gateway:
+  enabled: false
+  hostname: ""
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /health
+    port: 8940
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /health
+    port: 8940
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 2
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+nodeSelector: {}
+tolerations: []
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - medgemma-worker
+          topologyKey: kubernetes.io/hostname
+
+# Application configuration (ConfigMap)
+config:
+  NODE_ENV: production
+  LOG_LEVEL: info
+  PORT: "8940"
+
+# External Secrets
+externalSecrets:
+  enabled: false
+  secretStore: ""      # Defaults to <namespace>-secretstore
+  refreshInterval: 1h
+  secrets: []
+
+# Network Policy
+networkPolicy:
+  enabled: true
+  policyTypes:
+    - Ingress
+    - Egress
+  # ollamaEgress.cidr: CIDR of the external Ollama GPU endpoint.
+  # Set to the actual IP range in the deployment values file.
+  ollamaEgress:
+    enabled: true
+    cidr: "0.0.0.0/0"   # TODO: tighten to the actual Ollama host CIDR
+    port: 11434
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8940
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  path: /metrics

--- a/charts/medley/Chart.yaml
+++ b/charts/medley/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: medley
+description: Medley - Medical AI Gateway service (Hono/Bun backend)
+type: application
+version: 1.0.0
+appVersion: "0.1.0"
+keywords:
+  - medley
+  - ai
+  - medical
+  - hono
+  - bun
+home: https://github.com/mycurelabs/monobase-infra
+sources:
+  - https://github.com/mycurelabs/monobase
+maintainers:
+  - name: MyCure Labs
+    email: devops@mycure.md

--- a/charts/medley/templates/NOTES.txt
+++ b/charts/medley/templates/NOTES.txt
@@ -1,0 +1,73 @@
+{{- if .Values.enabled }}
+Medley Medical AI Gateway has been deployed!
+
+Chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+Release: {{ .Release.Name }}
+Namespace: {{ include "medley.namespace" . }}
+
+Deployment Information:
+  - Replicas: {{ .Values.replicaCount }}
+  - Image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+  - Service: {{ include "medley.fullname" . }}:{{ .Values.service.port }}
+
+Access Information:
+{{- if .Values.gateway.enabled }}
+  Medley: https://{{ include "medley.gateway.hostname" . }}
+
+  Test the API:
+  curl https://{{ include "medley.gateway.hostname" . }}/healthz
+{{- else }}
+  Gateway is disabled (ClusterIP only). Use port-forward to access:
+  kubectl port-forward -n {{ include "medley.namespace" . }} svc/{{ include "medley.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+{{- end }}
+
+Monitoring:
+{{- if .Values.serviceMonitor.enabled }}
+  ServiceMonitor enabled - Metrics available at /metrics
+{{- else }}
+  ServiceMonitor disabled - Enable for production monitoring
+{{- end }}
+
+Secrets:
+{{- if .Values.externalSecrets.enabled }}
+  External Secrets enabled - Syncing from {{ .Values.externalSecrets.secretStore | default (printf "%s-secretstore" (include "medley.namespace" .)) }}
+{{- else }}
+  External Secrets disabled - Ensure secrets are manually created
+{{- end }}
+
+Autoscaling:
+{{- if .Values.autoscaling.enabled }}
+  HPA enabled - {{ .Values.autoscaling.minReplicas }}-{{ .Values.autoscaling.maxReplicas }} replicas
+{{- else }}
+  HPA disabled - Fixed {{ .Values.replicaCount }} replicas
+{{- end }}
+
+Security:
+{{- if .Values.networkPolicy.enabled }}
+  NetworkPolicy enabled
+  {{- if .Values.networkPolicy.ollamaEgress.enabled }}
+  Ollama egress allowed to {{ .Values.networkPolicy.ollamaEgress.cidr }}:{{ .Values.networkPolicy.ollamaEgress.port }}
+  {{- end }}
+{{- else }}
+  NetworkPolicy disabled - Enable for production
+{{- end }}
+{{- if .Values.podDisruptionBudget.enabled }}
+  PodDisruptionBudget enabled (minAvailable: {{ .Values.podDisruptionBudget.minAvailable }})
+{{- else }}
+  PodDisruptionBudget disabled - Enable for HA
+{{- end }}
+
+Next Steps:
+  1. Verify pods are running:
+     kubectl get pods -n {{ include "medley.namespace" . }} -l app.kubernetes.io/name={{ include "medley.name" . }}
+
+  2. Check logs:
+     kubectl logs -n {{ include "medley.namespace" . }} -l app.kubernetes.io/name={{ include "medley.name" . }} --tail=50
+
+  3. Test health endpoint:
+     kubectl port-forward -n {{ include "medley.namespace" . }} svc/{{ include "medley.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+     curl http://localhost:{{ .Values.service.port }}/healthz
+
+{{- else }}
+Medley is disabled (enabled: false)
+{{- end }}

--- a/charts/medley/templates/_helpers.tpl
+++ b/charts/medley/templates/_helpers.tpl
@@ -1,0 +1,131 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "medley.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "medley.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "medley.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "medley.labels" -}}
+helm.sh/chart: {{ include "medley.chart" . }}
+{{ include "medley.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: monobase
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "medley.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "medley.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "medley.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "medley.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Gateway hostname - defaults to medley.{global.domain}
+*/}}
+{{- define "medley.gateway.hostname" -}}
+{{- if .Values.gateway.hostname }}
+{{- .Values.gateway.hostname }}
+{{- else }}
+{{- printf "medley.%s" .Values.global.domain }}
+{{- end }}
+{{- end }}
+
+{{/*
+Namespace - uses global.namespace or Release.Namespace
+*/}}
+{{- define "medley.namespace" -}}
+{{- default .Release.Namespace .Values.global.namespace }}
+{{- end }}
+
+{{/*
+Gateway parent reference name
+*/}}
+{{- define "medley.gateway.name" -}}
+{{- default "shared-gateway" .Values.global.gateway.name }}
+{{- end }}
+
+{{/*
+Gateway parent reference namespace
+*/}}
+{{- define "medley.gateway.namespace" -}}
+{{- default "gateway-system" .Values.global.gateway.namespace }}
+{{- end }}
+
+{{/*
+StorageClass name - auto-detects based on provider
+*/}}
+{{- define "medley.storageClass" -}}
+{{- if .Values.global.storage.className -}}
+{{- .Values.global.storage.className }}
+{{- else if eq .Values.global.storage.provider "longhorn" -}}
+longhorn
+{{- else if eq .Values.global.storage.provider "ebs-csi" -}}
+gp3
+{{- else if eq .Values.global.storage.provider "azure-disk" -}}
+managed-premium
+{{- else if eq .Values.global.storage.provider "gcp-pd" -}}
+pd-ssd
+{{- else if eq .Values.global.storage.provider "local-path" -}}
+local-path
+{{- else -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Node Pool - returns the effective node pool name (component-level or global)
+Returns empty string if disabled or not configured
+*/}}
+{{- define "medley.nodePool" -}}
+{{- if hasKey .Values "nodePool" -}}
+  {{- if and .Values.nodePool (hasKey .Values.nodePool "enabled") (not .Values.nodePool.enabled) -}}
+    {{- /* Component explicitly disabled node pool */ -}}
+  {{- else if and .Values.nodePool .Values.nodePool.name -}}
+    {{- .Values.nodePool.name -}}
+  {{- else if and .Values.global .Values.global.nodePool -}}
+    {{- .Values.global.nodePool -}}
+  {{- end -}}
+{{- else if and .Values.global .Values.global.nodePool -}}
+  {{- .Values.global.nodePool -}}
+{{- end -}}
+{{- end -}}

--- a/charts/medley/templates/configmap.yaml
+++ b/charts/medley/templates/configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "medley.fullname" . }}
+  namespace: {{ include "medley.namespace" . }}
+  labels:
+    {{- include "medley.labels" . | nindent 4 }}
+data:
+  NODE_ENV: {{ .Values.config.NODE_ENV | quote }}
+  LOG_LEVEL: {{ .Values.config.LOG_LEVEL | quote }}
+  PORT: {{ .Values.config.PORT | quote }}
+  {{- range $key, $value := .Values.config }}
+  {{- if not (has $key (list "NODE_ENV" "LOG_LEVEL" "PORT")) }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/medley/templates/deployment.yaml
+++ b/charts/medley/templates/deployment.yaml
@@ -1,0 +1,129 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "medley.fullname" . }}
+  namespace: {{ include "medley.namespace" . }}
+  labels:
+    {{- include "medley.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "medley.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "medley.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "medley.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.targetPort }}
+          protocol: TCP
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          {{- if .Values.livenessProbe.httpGet }}
+          httpGet:
+            path: {{ .Values.livenessProbe.httpGet.path }}
+            port: {{ .Values.livenessProbe.httpGet.port | default "http" }}
+          {{- end }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          {{- if .Values.readinessProbe.httpGet }}
+          httpGet:
+            path: {{ .Values.readinessProbe.httpGet.path }}
+            port: {{ .Values.readinessProbe.httpGet.port | default "http" }}
+          {{- end }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        env:
+        # Set HOME to /tmp to avoid permission denied errors when running as non-root
+        - name: HOME
+          value: "/tmp"
+        # Load from ConfigMap
+        - name: NODE_ENV
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "medley.fullname" . }}
+              key: NODE_ENV
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "medley.fullname" . }}
+              key: LOG_LEVEL
+        - name: PORT
+          value: "8970"
+        # Load secrets from External Secrets Operator
+        {{- if .Values.externalSecrets.enabled }}
+        {{- range .Values.externalSecrets.secrets }}
+        - name: {{ .secretKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "medley.fullname" $ }}-secrets
+              key: {{ .secretKey }}
+        {{- end }}
+        {{- end }}
+        # Additional environment variables from config
+        {{- range $key, $value := .Values.config }}
+        {{- if not (has $key (list "NODE_ENV" "LOG_LEVEL" "PORT")) }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+      {{- $nodePool := include "medley.nodePool" . -}}
+      {{- if or $nodePool .Values.nodeSelector }}
+      nodeSelector:
+        {{- if $nodePool }}
+        node-pool: {{ $nodePool }}
+        {{- end }}
+        {{- with .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or $nodePool .Values.tolerations }}
+      tolerations:
+        {{- if $nodePool }}
+        - key: "node-pool"
+          operator: "Equal"
+          value: {{ $nodePool | quote }}
+          effect: "NoSchedule"
+        {{- end }}
+        {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/charts/medley/templates/externalsecret.yaml
+++ b/charts/medley/templates/externalsecret.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.enabled .Values.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "medley.fullname" . }}-secrets
+  namespace: {{ include "medley.namespace" . }}
+  labels:
+    {{- include "medley.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStore | default (printf "%s-secretstore" (include "medley.namespace" .)) }}
+    kind: SecretStore
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | default "1h" }}
+  target:
+    name: {{ include "medley.fullname" . }}-secrets
+    creationPolicy: Owner
+  data:
+    {{- range .Values.externalSecrets.secrets }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ .remoteKey }}
+        {{- if .property }}
+        property: {{ .property }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/medley/templates/hpa.yaml
+++ b/charts/medley/templates/hpa.yaml
@@ -1,0 +1,50 @@
+{{- if and .Values.enabled .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "medley.fullname" . }}
+  namespace: {{ include "medley.namespace" . }}
+  labels:
+    {{- include "medley.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "medley.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+      selectPolicy: Max
+{{- end }}

--- a/charts/medley/templates/httproute.yaml
+++ b/charts/medley/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.enabled .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "medley.fullname" . }}
+  namespace: {{ include "medley.namespace" . }}
+  labels:
+    {{- include "medley.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "medley.gateway.name" . }}
+      namespace: {{ include "medley.gateway.namespace" . }}
+      sectionName: https  # Only attach to HTTPS listener
+      {{- if .Values.gateway.sectionName }}
+      # Override: {{ .Values.gateway.sectionName }}
+      {{- end }}
+  hostnames:
+    {{- if .Values.gateway.hostnames }}
+    {{- range .Values.gateway.hostnames }}
+    - {{ . }}
+    {{- end }}
+    {{- else }}
+    - {{ include "medley.gateway.hostname" . }}
+    {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "medley.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 1
+      {{- if .Values.gateway.filters }}
+      filters:
+        {{- toYaml .Values.gateway.filters | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/medley/templates/networkpolicy.yaml
+++ b/charts/medley/templates/networkpolicy.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.enabled .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "medley.fullname" . }}
+  namespace: {{ include "medley.namespace" . }}
+  labels:
+    {{- include "medley.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "medley.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- end }}
+  {{- if or .Values.networkPolicy.egress .Values.networkPolicy.ollamaEgress.enabled }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+    {{- if .Values.networkPolicy.ollamaEgress.enabled }}
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.networkPolicy.ollamaEgress.cidr }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.ollamaEgress.port }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/medley/templates/pdb.yaml
+++ b/charts/medley/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.enabled .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "medley.fullname" . }}
+  namespace: {{ include "medley.namespace" . }}
+  labels:
+    {{- include "medley.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "medley.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/medley/templates/service.yaml
+++ b/charts/medley/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "medley.fullname" . }}
+  namespace: {{ include "medley.namespace" . }}
+  labels:
+    {{- include "medley.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "medley.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/medley/templates/serviceaccount.yaml
+++ b/charts/medley/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.enabled .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "medley.serviceAccountName" . }}
+  namespace: {{ include "medley.namespace" . }}
+  labels:
+    {{- include "medley.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/medley/templates/servicemonitor.yaml
+++ b/charts/medley/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.enabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "medley.fullname" . }}
+  namespace: {{ include "medley.namespace" . }}
+  labels:
+    {{- include "medley.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "medley.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | default "/metrics" }}
+      interval: {{ .Values.serviceMonitor.interval | default "30s" }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+{{- end }}

--- a/charts/medley/values.yaml
+++ b/charts/medley/values.yaml
@@ -1,0 +1,180 @@
+# Default values for Medley chart
+# Override these values in values/deployments/*.yaml
+
+global:
+  domain: example.com
+  namespace: example-prod
+  environment: production
+  gateway:
+    name: shared-gateway
+    namespace: gateway-system
+  storage:
+    provider: ""
+    className: ""
+
+enabled: true
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/mycurelabs/medley
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+
+service:
+  type: ClusterIP
+  port: 8970
+  targetPort: 8970
+  annotations: {}
+
+# Gateway: disabled — medley is ClusterIP only, no public HTTPRoute
+gateway:
+  enabled: false
+  hostname: ""
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /healthz
+    port: 8970
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /healthz
+    port: 8970
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 2
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+nodeSelector: {}
+tolerations: []
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - medley
+          topologyKey: kubernetes.io/hostname
+
+# Application configuration (ConfigMap)
+# Secrets (e.g. MEDLEY_HISTORY_KEY) are mounted via externalSecrets below.
+config:
+  NODE_ENV: production
+  LOG_LEVEL: info
+  PORT: "8970"
+  HAPIHUB_URL: ""
+  OLLAMA_URL: ""       # Set to secured external GPU Ollama endpoint
+  MEDGEMMA_URL: ""
+  OPENMED_URL: ""
+  MEDLEY_CHAT_MODEL: ""
+  MEDLEY_CORS_ORIGINS: ""
+
+# External Secrets — MEDLEY_HISTORY_KEY pulled from GCP Secret Manager
+externalSecrets:
+  enabled: true
+  secretStore: ""      # Defaults to <namespace>-secretstore
+  refreshInterval: 1h
+  secrets: []          # Override in deployment values with MEDLEY_HISTORY_KEY entry
+
+# Network Policy
+networkPolicy:
+  enabled: true
+  policyTypes:
+    - Ingress
+    - Egress
+  # ollamaEgress.cidr: CIDR of the external Ollama GPU endpoint.
+  # Set to the actual IP range in the deployment values file.
+  # Placeholder: replace <<EXTERNAL_OLLAMA_URL_PLACEHOLDER>> with real host.
+  ollamaEgress:
+    enabled: true
+    cidr: "0.0.0.0/0"   # TODO: tighten to the actual Ollama host CIDR
+    port: 11434
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8970
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 5432   # PostgreSQL
+        - protocol: TCP
+          port: 6379   # Valkey
+        - protocol: TCP
+          port: 7500   # hapihub in-cluster
+        - protocol: TCP
+          port: 8940   # medgemma-worker in-cluster
+        - protocol: TCP
+          port: 8920   # openmed in-cluster
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  path: /metrics

--- a/charts/medleyapp/Chart.yaml
+++ b/charts/medleyapp/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: medleyapp
+description: Medley App - Medical AI frontend (Caddy SPA)
+type: application
+version: 1.0.0
+appVersion: "0.1.0"
+keywords:
+  - medleyapp
+  - ai
+  - medical
+  - frontend
+  - vue
+  - caddy
+home: https://github.com/mycurelabs/monobase-infra
+sources:
+  - https://github.com/mycurelabs/monobase
+maintainers:
+  - name: MyCure Labs
+    email: devops@mycure.md

--- a/charts/medleyapp/templates/NOTES.txt
+++ b/charts/medleyapp/templates/NOTES.txt
@@ -1,0 +1,43 @@
+{{- if .Values.enabled }}
+Medley App Frontend has been deployed!
+
+Chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+Release: {{ .Release.Name }}
+Namespace: {{ include "medleyapp.namespace" . }}
+
+Deployment Information:
+  - Replicas: {{ .Values.replicaCount }}
+  - Image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+  - Service: {{ include "medleyapp.fullname" . }}:{{ .Values.service.port }}
+
+Access Information:
+{{- if .Values.gateway.enabled }}
+  MedleyApp: https://{{ include "medleyapp.gateway.hostname" . }}
+
+  Open in browser:
+  open https://{{ include "medleyapp.gateway.hostname" . }}
+{{- else }}
+  Gateway is disabled. Use port-forward to access:
+  kubectl port-forward -n {{ include "medleyapp.namespace" . }} svc/{{ include "medleyapp.fullname" . }} 8080:{{ .Values.service.port }}
+  # Open http://localhost:8080
+{{- end }}
+
+Next Steps:
+  1. Verify pods are running:
+     kubectl get pods -n {{ include "medleyapp.namespace" . }} -l app.kubernetes.io/name={{ include "medleyapp.name" . }}
+
+  2. Check logs:
+     kubectl logs -n {{ include "medleyapp.namespace" . }} -l app.kubernetes.io/name={{ include "medleyapp.name" . }} --tail=50
+
+  3. Test frontend:
+     curl https://{{ include "medleyapp.gateway.hostname" . }}
+
+Frontend Features:
+  - Static file serving (Caddy)
+  - Read-only root filesystem (security)
+  - CDN-ready configuration
+  - Environment variable injection
+
+{{- else }}
+MedleyApp Frontend is disabled (enabled: false)
+{{- end }}

--- a/charts/medleyapp/templates/_helpers.tpl
+++ b/charts/medleyapp/templates/_helpers.tpl
@@ -1,0 +1,111 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "medleyapp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "medleyapp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "medleyapp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "medleyapp.labels" -}}
+helm.sh/chart: {{ include "medleyapp.chart" . }}
+{{ include "medleyapp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: medleyapp
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "medleyapp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "medleyapp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "medleyapp.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "medleyapp.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Gateway hostname - defaults to medleyapp.{global.domain}
+*/}}
+{{- define "medleyapp.gateway.hostname" -}}
+{{- if .Values.gateway.hostname }}
+{{- .Values.gateway.hostname }}
+{{- else }}
+{{- printf "medleyapp.%s" .Values.global.domain }}
+{{- end }}
+{{- end }}
+
+{{/*
+Namespace - uses global.namespace or Release.Namespace
+*/}}
+{{- define "medleyapp.namespace" -}}
+{{- default .Release.Namespace .Values.global.namespace }}
+{{- end }}
+
+{{/*
+Gateway parent reference name
+*/}}
+{{- define "medleyapp.gateway.name" -}}
+{{- default "shared-gateway" .Values.global.gateway.name }}
+{{- end }}
+
+{{/*
+Gateway parent reference namespace
+*/}}
+{{- define "medleyapp.gateway.namespace" -}}
+{{- default "gateway-system" .Values.global.gateway.namespace }}
+{{- end }}
+
+{{/*
+Node Pool - returns the effective node pool name (component-level or global)
+Returns empty string if disabled or not configured
+*/}}
+{{- define "medleyapp.nodePool" -}}
+{{- if hasKey .Values "nodePool" -}}
+  {{- if and .Values.nodePool (hasKey .Values.nodePool "enabled") (not .Values.nodePool.enabled) -}}
+    {{- /* Component explicitly disabled node pool */ -}}
+  {{- else if and .Values.nodePool .Values.nodePool.name -}}
+    {{- .Values.nodePool.name -}}
+  {{- else if and .Values.global .Values.global.nodePool -}}
+    {{- .Values.global.nodePool -}}
+  {{- end -}}
+{{- else if and .Values.global .Values.global.nodePool -}}
+  {{- .Values.global.nodePool -}}
+{{- end -}}
+{{- end -}}

--- a/charts/medleyapp/templates/configmap.yaml
+++ b/charts/medleyapp/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.enabled .Values.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "medleyapp.fullname" . }}
+  namespace: {{ include "medleyapp.namespace" . }}
+  labels:
+    {{- include "medleyapp.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/medleyapp/templates/deployment.yaml
+++ b/charts/medleyapp/templates/deployment.yaml
@@ -1,0 +1,109 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "medleyapp.fullname" . }}
+  namespace: {{ include "medleyapp.namespace" . }}
+  labels:
+    {{- include "medleyapp.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "medleyapp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "medleyapp.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "medleyapp.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.targetPort }}
+          protocol: TCP
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.livenessProbe.httpGet.path }}
+            port: {{ .Values.livenessProbe.httpGet.port | default "http" }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.readinessProbe.httpGet.path }}
+            port: {{ .Values.readinessProbe.httpGet.port | default "http" }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.config }}
+        env:
+        {{- range $key, $value := .Values.config }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        # Caddy volumes for tmp, data, and config (read-only root filesystem)
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: caddy-data
+          mountPath: /data
+        - name: caddy-config
+          mountPath: /config
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: caddy-data
+        emptyDir: {}
+      - name: caddy-config
+        emptyDir: {}
+      {{- $nodePool := include "medleyapp.nodePool" . -}}
+      {{- if or $nodePool .Values.nodeSelector }}
+      nodeSelector:
+        {{- if $nodePool }}
+        node-pool: {{ $nodePool }}
+        {{- end }}
+        {{- with .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or $nodePool .Values.tolerations }}
+      tolerations:
+        {{- if $nodePool }}
+        - key: "node-pool"
+          operator: "Equal"
+          value: {{ $nodePool | quote }}
+          effect: "NoSchedule"
+        {{- end }}
+        {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/charts/medleyapp/templates/hpa.yaml
+++ b/charts/medleyapp/templates/hpa.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.enabled .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "medleyapp.fullname" . }}
+  namespace: {{ include "medleyapp.namespace" . }}
+  labels:
+    {{- include "medleyapp.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "medleyapp.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/medleyapp/templates/httproute.yaml
+++ b/charts/medleyapp/templates/httproute.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.enabled .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "medleyapp.fullname" . }}
+  namespace: {{ include "medleyapp.namespace" . }}
+  labels:
+    {{- include "medleyapp.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "medleyapp.gateway.name" . }}
+      namespace: {{ include "medleyapp.gateway.namespace" . }}
+      {{- if .Values.gateway.sectionName }}
+      sectionName: {{ .Values.gateway.sectionName }}
+      {{- else }}
+      sectionName: https  # Default: attach to HTTPS listener
+      {{- end }}
+  hostnames:
+    {{- if .Values.gateway.hostnames }}
+    {{- range .Values.gateway.hostnames }}
+    - {{ . }}
+    {{- end }}
+    {{- else }}
+    - {{ include "medleyapp.gateway.hostname" . }}
+    {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "medleyapp.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 1
+{{- end }}

--- a/charts/medleyapp/templates/networkpolicy.yaml
+++ b/charts/medleyapp/templates/networkpolicy.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.enabled .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "medleyapp.fullname" . }}
+  namespace: {{ include "medleyapp.namespace" . }}
+  labels:
+    {{- include "medleyapp.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "medleyapp.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
+{{- end }}

--- a/charts/medleyapp/templates/pdb.yaml
+++ b/charts/medleyapp/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.enabled .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "medleyapp.fullname" . }}
+  namespace: {{ include "medleyapp.namespace" . }}
+  labels:
+    {{- include "medleyapp.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "medleyapp.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/medleyapp/templates/service.yaml
+++ b/charts/medleyapp/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "medleyapp.fullname" . }}
+  namespace: {{ include "medleyapp.namespace" . }}
+  labels:
+    {{- include "medleyapp.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "medleyapp.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/medleyapp/templates/serviceaccount.yaml
+++ b/charts/medleyapp/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.enabled .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "medleyapp.serviceAccountName" . }}
+  namespace: {{ include "medleyapp.namespace" . }}
+  labels:
+    {{- include "medleyapp.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/medleyapp/templates/servicemonitor.yaml
+++ b/charts/medleyapp/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.enabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "medleyapp.fullname" . }}
+  namespace: {{ include "medleyapp.namespace" . }}
+  labels:
+    {{- include "medleyapp.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "medleyapp.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | default "/metrics" }}
+      interval: {{ .Values.serviceMonitor.interval | default "30s" }}
+{{- end }}

--- a/charts/medleyapp/values.yaml
+++ b/charts/medleyapp/values.yaml
@@ -1,0 +1,115 @@
+# Default values for MedleyApp chart
+# Override these values in values/deployments/*.yaml
+
+global:
+  domain: example.com
+  namespace: example-prod
+  environment: production
+  gateway:
+    name: shared-gateway
+    namespace: gateway-system
+
+enabled: true
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/mycurelabs/medleyapp
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 101  # caddy-k8s user
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+  annotations: {}
+
+gateway:
+  enabled: true
+  hostname: ""  # Empty = uses medleyapp.{global.domain}
+  sectionName: ""  # Override gateway listener section name
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 512Mi
+
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 5
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# Node pool scheduling (optional, disabled by default)
+# Inherits from global.nodePool if configured
+# nodePool:
+#   enabled: false     # Set to false to explicitly disable (overrides global)
+#   name: "staging"    # Override global node pool name
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Frontend configuration (passed as environment variables to the container)
+config:
+  MEDLEY_URL: ""   # Set to Medley backend URL (in-cluster or public)
+  API_URL: ""      # Set to HapiHub public URL
+
+networkPolicy:
+  enabled: true
+  policyTypes:
+    - Ingress
+    - Egress
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  path: /metrics

--- a/charts/ollama-egress/Chart.yaml
+++ b/charts/ollama-egress/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: ollama-egress
+description: Tailscale egress from the cluster to the vanaheim workstation's Ollama (medical-AI inference)
+version: 0.1.0

--- a/charts/ollama-egress/templates/deployment.yaml
+++ b/charts/ollama-egress/templates/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama-egress
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: ollama-egress }
+  template:
+    metadata:
+      labels: { app: ollama-egress }
+    spec:
+      containers:
+        - name: ts
+          image: {{ .Values.tailscaleImage }}
+          env:
+            - { name: TS_AUTHKEY, valueFrom: { secretKeyRef: { name: ollama-egress-authkey, key: TS_AUTHKEY } } }
+            - { name: TS_USERSPACE, value: "false" }
+            - { name: TS_STATE_DIR, value: "/tmp" }
+            - { name: TS_KUBE_SECRET, value: "" }
+            - { name: TS_EXTRA_ARGS, value: "--hostname={{ .Values.hostname }}" }
+          securityContext:
+            capabilities: { add: ["NET_ADMIN"] }
+        # socat sidecar forwards the cluster Service traffic to vanaheim over the tailnet
+        # (TS_DEST_IP alone only DNATs tailnet-side traffic, not the cluster Service path).
+        - name: forward
+          image: {{ .Values.socatImage }}
+          args: ["TCP-LISTEN:{{ .Values.port }},fork,reuseaddr","TCP:{{ .Values.destIP }}:{{ .Values.port }}"]
+          ports:
+            - containerPort: {{ .Values.port }}

--- a/charts/ollama-egress/templates/externalsecret.yaml
+++ b/charts/ollama-egress/templates/externalsecret.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.externalSecret.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ollama-egress-authkey
+  namespace: {{ .Values.namespace }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.externalSecret.secretStore }}
+    kind: {{ .Values.externalSecret.secretStoreKind }}
+  target:
+    name: ollama-egress-authkey
+    creationPolicy: Owner
+  data:
+    - secretKey: TS_AUTHKEY
+      remoteRef:
+        key: {{ .Values.externalSecret.remoteKey }}
+{{- end }}

--- a/charts/ollama-egress/templates/namespace.yaml
+++ b/charts/ollama-egress/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/charts/ollama-egress/templates/service.yaml
+++ b/charts/ollama-egress/templates/service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: {{ .Values.namespace }}
+spec:
+  selector: { app: ollama-egress }
+  ports:
+    - { name: ollama, port: {{ .Values.port }}, targetPort: {{ .Values.port }}, protocol: TCP }

--- a/charts/ollama-egress/values.yaml
+++ b/charts/ollama-egress/values.yaml
@@ -1,0 +1,13 @@
+# Egress to an Ollama on the tailnet. Lives in its own privileged namespace because the app
+# namespaces are PSA=restricted (which forbids the NET_ADMIN the tailscale kernel mode needs).
+namespace: tailscale
+destIP: "100.120.88.93"          # vanaheim's tailnet IP
+port: 11434
+hostname: ollama-egress-preprod
+tailscaleImage: tailscale/tailscale:v1.84.3
+socatImage: alpine/socat:latest
+externalSecret:
+  enabled: true
+  secretStore: gcp-secretstore
+  secretStoreKind: ClusterSecretStore
+  remoteKey: mycure-preprod-tailscale-ollama-authkey

--- a/charts/openmed/Chart.yaml
+++ b/charts/openmed/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: openmed
+description: OpenMed - Medical AI model serving service (Hono/Bun backend)
+type: application
+version: 1.0.0
+appVersion: "0.1.0"
+keywords:
+  - openmed
+  - ai
+  - medical
+  - hono
+  - bun
+home: https://github.com/mycurelabs/monobase-infra
+sources:
+  - https://github.com/mycurelabs/monobase
+maintainers:
+  - name: MyCure Labs
+    email: devops@mycure.md

--- a/charts/openmed/templates/NOTES.txt
+++ b/charts/openmed/templates/NOTES.txt
@@ -1,0 +1,56 @@
+{{- if .Values.enabled }}
+OpenMed Medical AI Model Server has been deployed!
+
+Chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+Release: {{ .Release.Name }}
+Namespace: {{ include "openmed.namespace" . }}
+
+Deployment Information:
+  - Replicas: {{ .Values.replicaCount }}
+  - Image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+  - Service: {{ include "openmed.fullname" . }}:{{ .Values.service.port }}
+
+Model Cache:
+{{- if .Values.persistence.enabled }}
+  PVC: {{ include "openmed.pvcName" . }} ({{ .Values.persistence.size }})
+  Mount: /models (HF_HOME=/models)
+  Models persist across pod restarts.
+{{- else }}
+  Persistence disabled - models will be re-downloaded on each restart.
+{{- end }}
+
+Access Information:
+  Gateway is disabled (ClusterIP only). Use port-forward to access:
+  kubectl port-forward -n {{ include "openmed.namespace" . }} svc/{{ include "openmed.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+
+Monitoring:
+{{- if .Values.serviceMonitor.enabled }}
+  ServiceMonitor enabled - Metrics available at /metrics
+{{- else }}
+  ServiceMonitor disabled - Enable for production monitoring
+{{- end }}
+
+Security:
+{{- if .Values.networkPolicy.enabled }}
+  NetworkPolicy enabled
+{{- else }}
+  NetworkPolicy disabled - Enable for production
+{{- end }}
+
+Next Steps:
+  1. Verify pods are running:
+     kubectl get pods -n {{ include "openmed.namespace" . }} -l app.kubernetes.io/name={{ include "openmed.name" . }}
+
+  2. Check logs:
+     kubectl logs -n {{ include "openmed.namespace" . }} -l app.kubernetes.io/name={{ include "openmed.name" . }} --tail=50
+
+  3. Test health endpoint:
+     kubectl port-forward -n {{ include "openmed.namespace" . }} svc/{{ include "openmed.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+     curl http://localhost:{{ .Values.service.port }}/health
+
+  4. Check PVC status:
+     kubectl get pvc -n {{ include "openmed.namespace" . }} {{ include "openmed.pvcName" . }}
+
+{{- else }}
+OpenMed is disabled (enabled: false)
+{{- end }}

--- a/charts/openmed/templates/_helpers.tpl
+++ b/charts/openmed/templates/_helpers.tpl
@@ -1,0 +1,145 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openmed.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "openmed.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openmed.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "openmed.labels" -}}
+helm.sh/chart: {{ include "openmed.chart" . }}
+{{ include "openmed.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: monobase
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "openmed.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openmed.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "openmed.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "openmed.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Gateway hostname - defaults to openmed.{global.domain}
+*/}}
+{{- define "openmed.gateway.hostname" -}}
+{{- if .Values.gateway.hostname }}
+{{- .Values.gateway.hostname }}
+{{- else }}
+{{- printf "openmed.%s" .Values.global.domain }}
+{{- end }}
+{{- end }}
+
+{{/*
+Namespace - uses global.namespace or Release.Namespace
+*/}}
+{{- define "openmed.namespace" -}}
+{{- default .Release.Namespace .Values.global.namespace }}
+{{- end }}
+
+{{/*
+Gateway parent reference name
+*/}}
+{{- define "openmed.gateway.name" -}}
+{{- default "shared-gateway" .Values.global.gateway.name }}
+{{- end }}
+
+{{/*
+Gateway parent reference namespace
+*/}}
+{{- define "openmed.gateway.namespace" -}}
+{{- default "gateway-system" .Values.global.gateway.namespace }}
+{{- end }}
+
+{{/*
+StorageClass name - auto-detects based on provider
+*/}}
+{{- define "openmed.storageClass" -}}
+{{- if .Values.persistence.storageClassName -}}
+{{- .Values.persistence.storageClassName }}
+{{- else if .Values.global.storage.className -}}
+{{- .Values.global.storage.className }}
+{{- else if eq .Values.global.storage.provider "longhorn" -}}
+longhorn
+{{- else if eq .Values.global.storage.provider "ebs-csi" -}}
+gp3
+{{- else if eq .Values.global.storage.provider "azure-disk" -}}
+managed-premium
+{{- else if eq .Values.global.storage.provider "gcp-pd" -}}
+pd-ssd
+{{- else if eq .Values.global.storage.provider "local-path" -}}
+local-path
+{{- else -}}
+longhorn
+{{- end -}}
+{{- end }}
+
+{{/*
+PVC name for model cache
+*/}}
+{{- define "openmed.pvcName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim }}
+{{- else -}}
+openmed-model-cache
+{{- end -}}
+{{- end }}
+
+{{/*
+Node Pool - returns the effective node pool name (component-level or global)
+Returns empty string if disabled or not configured
+*/}}
+{{- define "openmed.nodePool" -}}
+{{- if hasKey .Values "nodePool" -}}
+  {{- if and .Values.nodePool (hasKey .Values.nodePool "enabled") (not .Values.nodePool.enabled) -}}
+    {{- /* Component explicitly disabled node pool */ -}}
+  {{- else if and .Values.nodePool .Values.nodePool.name -}}
+    {{- .Values.nodePool.name -}}
+  {{- else if and .Values.global .Values.global.nodePool -}}
+    {{- .Values.global.nodePool -}}
+  {{- end -}}
+{{- else if and .Values.global .Values.global.nodePool -}}
+  {{- .Values.global.nodePool -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openmed/templates/configmap.yaml
+++ b/charts/openmed/templates/configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openmed.fullname" . }}
+  namespace: {{ include "openmed.namespace" . }}
+  labels:
+    {{- include "openmed.labels" . | nindent 4 }}
+data:
+  NODE_ENV: {{ .Values.config.NODE_ENV | quote }}
+  LOG_LEVEL: {{ .Values.config.LOG_LEVEL | quote }}
+  PORT: {{ .Values.config.PORT | quote }}
+  {{- range $key, $value := .Values.config }}
+  {{- if not (has $key (list "NODE_ENV" "LOG_LEVEL" "PORT")) }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/openmed/templates/deployment.yaml
+++ b/charts/openmed/templates/deployment.yaml
@@ -1,0 +1,139 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openmed.fullname" . }}
+  namespace: {{ include "openmed.namespace" . }}
+  labels:
+    {{- include "openmed.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "openmed.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "openmed.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "openmed.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.targetPort }}
+          protocol: TCP
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          {{- if .Values.livenessProbe.httpGet }}
+          httpGet:
+            path: {{ .Values.livenessProbe.httpGet.path }}
+            port: {{ .Values.livenessProbe.httpGet.port | default "http" }}
+          {{- end }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          {{- if .Values.readinessProbe.httpGet }}
+          httpGet:
+            path: {{ .Values.readinessProbe.httpGet.path }}
+            port: {{ .Values.readinessProbe.httpGet.port | default "http" }}
+          {{- end }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        env:
+        # Set HOME to /tmp to avoid permission denied errors when running as non-root
+        - name: HOME
+          value: "/tmp"
+        # Load from ConfigMap
+        - name: NODE_ENV
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "openmed.fullname" . }}
+              key: NODE_ENV
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "openmed.fullname" . }}
+              key: LOG_LEVEL
+        - name: PORT
+          value: "8920"
+        # HuggingFace model cache directory (backed by PVC)
+        - name: HF_HOME
+          value: /models
+        # Load secrets from External Secrets Operator
+        {{- if .Values.externalSecrets.enabled }}
+        {{- range .Values.externalSecrets.secrets }}
+        - name: {{ .secretKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "openmed.fullname" $ }}-secrets
+              key: {{ .secretKey }}
+        {{- end }}
+        {{- end }}
+        # Additional environment variables from config
+        {{- range $key, $value := .Values.config }}
+        {{- if not (has $key (list "NODE_ENV" "LOG_LEVEL" "PORT" "HF_HOME")) }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        volumeMounts:
+        - name: model-cache
+          mountPath: /models
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: {{ include "openmed.pvcName" . }}
+      {{- $nodePool := include "openmed.nodePool" . -}}
+      {{- if or $nodePool .Values.nodeSelector }}
+      nodeSelector:
+        {{- if $nodePool }}
+        node-pool: {{ $nodePool }}
+        {{- end }}
+        {{- with .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or $nodePool .Values.tolerations }}
+      tolerations:
+        {{- if $nodePool }}
+        - key: "node-pool"
+          operator: "Equal"
+          value: {{ $nodePool | quote }}
+          effect: "NoSchedule"
+        {{- end }}
+        {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/charts/openmed/templates/externalsecret.yaml
+++ b/charts/openmed/templates/externalsecret.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.enabled .Values.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "openmed.fullname" . }}-secrets
+  namespace: {{ include "openmed.namespace" . }}
+  labels:
+    {{- include "openmed.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStore | default (printf "%s-secretstore" (include "openmed.namespace" .)) }}
+    kind: SecretStore
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | default "1h" }}
+  target:
+    name: {{ include "openmed.fullname" . }}-secrets
+    creationPolicy: Owner
+  data:
+    {{- range .Values.externalSecrets.secrets }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ .remoteKey }}
+        {{- if .property }}
+        property: {{ .property }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/openmed/templates/hpa.yaml
+++ b/charts/openmed/templates/hpa.yaml
@@ -1,0 +1,50 @@
+{{- if and .Values.enabled .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "openmed.fullname" . }}
+  namespace: {{ include "openmed.namespace" . }}
+  labels:
+    {{- include "openmed.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "openmed.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+      selectPolicy: Max
+{{- end }}

--- a/charts/openmed/templates/httproute.yaml
+++ b/charts/openmed/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.enabled .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "openmed.fullname" . }}
+  namespace: {{ include "openmed.namespace" . }}
+  labels:
+    {{- include "openmed.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "openmed.gateway.name" . }}
+      namespace: {{ include "openmed.gateway.namespace" . }}
+      sectionName: https  # Only attach to HTTPS listener
+      {{- if .Values.gateway.sectionName }}
+      # Override: {{ .Values.gateway.sectionName }}
+      {{- end }}
+  hostnames:
+    {{- if .Values.gateway.hostnames }}
+    {{- range .Values.gateway.hostnames }}
+    - {{ . }}
+    {{- end }}
+    {{- else }}
+    - {{ include "openmed.gateway.hostname" . }}
+    {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "openmed.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 1
+      {{- if .Values.gateway.filters }}
+      filters:
+        {{- toYaml .Values.gateway.filters | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/openmed/templates/networkpolicy.yaml
+++ b/charts/openmed/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.enabled .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "openmed.fullname" . }}
+  namespace: {{ include "openmed.namespace" . }}
+  labels:
+    {{- include "openmed.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openmed.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- end }}
+  {{- if .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/openmed/templates/pdb.yaml
+++ b/charts/openmed/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.enabled .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "openmed.fullname" . }}
+  namespace: {{ include "openmed.namespace" . }}
+  labels:
+    {{- include "openmed.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "openmed.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/openmed/templates/pvc.yaml
+++ b/charts/openmed/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.enabled .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+# PersistentVolumeClaim for Hugging Face model cache
+# Mounted at /models (HF_HOME=/models) to persist downloaded models across pod restarts.
+# Storage class defaults to global.storage.className or longhorn.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openmed-model-cache
+  namespace: {{ include "openmed.namespace" . }}
+  labels:
+    {{- include "openmed.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | default "3Gi" }}
+  {{- $storageClass := include "openmed.storageClass" . }}
+  {{- if $storageClass }}
+  storageClassName: {{ $storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/openmed/templates/service.yaml
+++ b/charts/openmed/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openmed.fullname" . }}
+  namespace: {{ include "openmed.namespace" . }}
+  labels:
+    {{- include "openmed.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "openmed.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/openmed/templates/serviceaccount.yaml
+++ b/charts/openmed/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.enabled .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openmed.serviceAccountName" . }}
+  namespace: {{ include "openmed.namespace" . }}
+  labels:
+    {{- include "openmed.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/openmed/templates/servicemonitor.yaml
+++ b/charts/openmed/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.enabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openmed.fullname" . }}
+  namespace: {{ include "openmed.namespace" . }}
+  labels:
+    {{- include "openmed.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "openmed.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | default "/metrics" }}
+      interval: {{ .Values.serviceMonitor.interval | default "30s" }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+{{- end }}

--- a/charts/openmed/values.yaml
+++ b/charts/openmed/values.yaml
@@ -1,0 +1,167 @@
+# Default values for OpenMed chart
+# Override these values in values/deployments/*.yaml
+
+global:
+  domain: example.com
+  namespace: example-prod
+  environment: production
+  gateway:
+    name: shared-gateway
+    namespace: gateway-system
+  storage:
+    provider: ""
+    className: ""
+
+enabled: true
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/mycurelabs/openmed
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+
+service:
+  type: ClusterIP
+  port: 8920
+  targetPort: 8920
+  annotations: {}
+
+# Gateway: disabled — openmed is ClusterIP only, no public HTTPRoute
+gateway:
+  enabled: false
+  hostname: ""
+
+# Larger memory defaults due to model serving requirements
+resources:
+  requests:
+    cpu: 500m
+    memory: 768Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /health
+    port: 8920
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /health
+    port: 8920
+  initialDelaySeconds: 20
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 2
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+nodeSelector: {}
+tolerations: []
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - openmed
+          topologyKey: kubernetes.io/hostname
+
+# Application configuration (ConfigMap)
+config:
+  NODE_ENV: production
+  LOG_LEVEL: info
+  PORT: "8920"
+  HF_HOME: /models   # Hugging Face model cache mount point
+
+# External Secrets
+externalSecrets:
+  enabled: false
+  secretStore: ""      # Defaults to <namespace>-secretstore
+  refreshInterval: 1h
+  secrets: []
+
+# PersistentVolumeClaim for Hugging Face model cache
+# Mounted at /models (HF_HOME=/models)
+persistence:
+  enabled: true
+  existingClaim: ""    # Set to use an existing PVC instead of creating one
+  size: 3Gi
+  accessMode: ReadWriteOnce
+  storageClassName: "" # Defaults to global.storage.className or longhorn
+
+# Network Policy
+networkPolicy:
+  enabled: true
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8920
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443    # HuggingFace Hub download
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  path: /metrics

--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -209,7 +209,14 @@ hapihub:
       rpId: "preprod.localfirsthealth.com"
 
   config:
-    CORS_ORIGINS: "https://hapihub.preprod.localfirsthealth.com,https://mycure.preprod.localfirsthealth.com,https://mycurelocal.preprod.localfirsthealth.com,https://mycure-myaccount.preprod.localfirsthealth.com,https://mycure-deploydash.preprod.localfirsthealth.com,https://mycure-dashboard.preprod.localfirsthealth.com,https://mycure-pxp.preprod.localfirsthealth.com,https://dentalemon.preprod.localfirsthealth.com,https://dentalemon-myaccount.preprod.localfirsthealth.com,https://dentalemon-website.preprod.localfirsthealth.com,https://mycure-pr--*.web.app"
+    CORS_ORIGINS: "https://hapihub.preprod.localfirsthealth.com,https://mycure.preprod.localfirsthealth.com,https://mycurelocal.preprod.localfirsthealth.com,https://mycure-myaccount.preprod.localfirsthealth.com,https://mycure-deploydash.preprod.localfirsthealth.com,https://mycure-dashboard.preprod.localfirsthealth.com,https://mycure-pxp.preprod.localfirsthealth.com,https://dentalemon.preprod.localfirsthealth.com,https://dentalemon-myaccount.preprod.localfirsthealth.com,https://dentalemon-website.preprod.localfirsthealth.com,https://mycure-pr--*.web.app,https://medleyapp.preprod.localfirsthealth.com"
+    # ---- Phase 2: medical-AI integration (uncomment when medley+medgemma-worker+openmed are enabled) ----
+    # INGESTION_ENABLED: "true"
+    # OPENMED_ENABLED: "true"
+    # MEDGEMMA_URL: "http://medgemma-worker:8940"
+    # OLLAMA_URL: "http://ollama.tailscale.svc.cluster.local:11434"  # TODO: set to the secured external GPU Ollama endpoint
+    # OPENMED_URL: "http://openmed:8920"
+    # EMBED_MODEL: "nomic-embed-text"
     CORS_STRICT: "true"
     CORS_ALLOW_LOCAL_NETWORK: "false"
     CORS_ALLOW_MOBILE_APPS: "true"
@@ -475,6 +482,150 @@ hapihub-docs:
   gateway:
     hostname: "docs.preprod.localfirsthealth.com"
     sectionName: https-preprod-lfh
+
+  podDisruptionBudget:
+    enabled: false
+
+# ===== MEDICAL AI: Medley AI Gateway =====
+# Phase 1: enabled — ClusterIP only, reachable at http://medley:8970 in-cluster.
+# MEDLEY_HISTORY_KEY pulled from GCP Secret Manager (mycure-preprod-medley-history-key).
+medley:
+  enabled: true
+
+  image:
+    repository: ghcr.io/mycurelabs/medley
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+  gateway:
+    enabled: false  # ClusterIP only — no public HTTPRoute
+
+  config:
+    HAPIHUB_URL: "http://hapihub:7500"
+    # TODO: set to the secured external GPU Ollama endpoint before enabling medgemma-worker
+    OLLAMA_URL: "http://ollama.tailscale.svc.cluster.local:11434"
+    MEDGEMMA_URL: "http://medgemma-worker:8940"
+    OPENMED_URL: "http://openmed:8920"
+    MEDLEY_CHAT_MODEL: "qwen3.5:9b"
+    MEDLEY_CORS_ORIGINS: "https://medleyapp.preprod.localfirsthealth.com"
+
+  externalSecrets:
+    enabled: true
+    secretStore: gcp-secretstore
+    secretStoreKind: ClusterSecretStore
+    refreshInterval: 1h
+    secrets:
+      - secretKey: MEDLEY_HISTORY_KEY
+        remoteKey: mycure-preprod-medley-history-key
+
+  podDisruptionBudget:
+    enabled: false
+
+# ===== MEDICAL AI: MedleyApp Frontend (Caddy SPA) =====
+# Phase 1: enabled — public HTTPRoute via https-preprod-lfh.
+medleyapp:
+  enabled: true
+
+  image:
+    repository: ghcr.io/mycurelabs/medleyapp
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+  gateway:
+    hostname: ""  # defaults to medleyapp.preprod.localfirsthealth.com
+    sectionName: https-preprod-lfh
+
+  config:
+    API_URL: "https://hapihub.preprod.localfirsthealth.com"
+    HAPIHUB_URL: "https://hapihub.preprod.localfirsthealth.com"
+
+  podDisruptionBudget:
+    enabled: false
+
+# ===== MEDICAL AI: MedGemma Worker =====
+# Phase 2: disabled — requires external Ollama GPU endpoint.
+# Enable after http://ollama.tailscale.svc.cluster.local:11434 is resolved and
+# hapihub Phase-2 env vars (INGESTION_ENABLED, OPENMED_ENABLED, etc.) are uncommented.
+medgemmaWorker:
+  enabled: false
+
+  image:
+    repository: ghcr.io/mycurelabs/medgemma-worker
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+  gateway:
+    enabled: false  # ClusterIP only
+
+  config:
+    # TODO: set to the secured external GPU Ollama endpoint
+    OLLAMA_URL: "http://ollama.tailscale.svc.cluster.local:11434"
+    MEDGEMMA_MODEL: "hf.co/unsloth/medgemma-4b-it-GGUF:Q4_K_M"
+
+  podDisruptionBudget:
+    enabled: false
+
+# ===== MEDICAL AI: OpenMed Model Server =====
+# Phase 2: disabled — requires PVC (3Gi) for HF model cache + external Ollama.
+# PVC (openmed-model-cache, ReadWriteOnce, 3Gi) is created by charts/openmed/templates/pvc.yaml
+# when persistence.enabled=true. Models are persisted across restarts at /models (HF_HOME).
+openmed:
+  enabled: false
+
+  image:
+    repository: ghcr.io/mycurelabs/openmed
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 768Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+
+  gateway:
+    enabled: false  # ClusterIP only
+
+  config:
+    OPENMED_PRELOAD: "disease,pharma"
+
+  persistence:
+    enabled: true
+    size: 3Gi
 
   podDisruptionBudget:
     enabled: false

--- a/values/infrastructure/main.yaml
+++ b/values/infrastructure/main.yaml
@@ -475,3 +475,7 @@ monitoring:
       smarthost: ""  # SMTP server (e.g., smtp.gmail.com:587)
       from: ""  # From email address
       to: ""  # To email address
+
+# Tailscale egress to the vanaheim workstation Ollama (medical-AI preprod inference)
+ollamaEgress:
+  enabled: true


### PR DESCRIPTION
Deploys the medical-AI stack to **mycure-preprod**, with LLM inference bridged to a GPU workstation over Tailscale.

## What
- **charts/{medley,medgemma-worker,openmed,medleyapp}** + ArgoCD app templates + preprod values blocks.
- **charts/ollama-egress** — Tailscale egress (kernel-mode tailscale + socat sidecar) in a privileged `tailscale` namespace → `Service ollama.tailscale.svc:11434` ⇒ the workstation's Ollama. Auth key via ExternalSecret from GCP SM. (App namespaces are PSA=restricted, can't host NET_ADMIN.)
- medley `OLLAMA_URL=http://ollama.tailscale.svc.cluster.local:11434`; medleyapp origin added to hapihub CORS; medley history key via GCP SM.

## Phasing
- **Phase 1 (enabled):** medley + medleyapp + ollama-egress.
- **Phase 2 (disabled):** medgemma-worker + openmed + hapihub INGESTION/OPENMED flip.

## Verified before this PR
- All 4 images pushed: `ghcr.io/mycurelabs/{medley,medgemma-worker,openmed,medleyapp}:0.1.0` (medley 421MB).
- The egress is **live + verified**: in-cluster `curl http://ollama.tailscale.svc:11434/api/tags` returns the workstation's models. All 5 charts `helm template` clean.

## Note / risk
- The workstation is a preprod inference SPOF. The egress is currently kubectl-bootstrapped in an un-Argo'd namespace; this PR codifies it so ArgoCD adopts it on sync.