### PR TITLE
fix(medley): externalSecret ClusterSecretStore kind

### DIFF
--- a/charts/medley/templates/externalsecret.yaml
+++ b/charts/medley/templates/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     name: {{ .Values.externalSecrets.secretStore | default (printf "%s-secretstore" (include "medley.namespace" .)) }}
-    kind: SecretStore
+    kind: {{ .Values.externalSecrets.secretStoreKind | default "SecretStore" }}
   refreshInterval: {{ .Values.externalSecrets.refreshInterval | default "1h" }}
   target:
     name: {{ include "medley.fullname" . }}-secrets


### PR DESCRIPTION
medley chart hardcoded `kind: SecretStore` but `gcp-secretstore` is a ClusterSecretStore → ES sync failed. Honor `externalSecrets.secretStoreKind` (values already set ClusterSecretStore).