### PR TITLE
chore(cadence): bump 0.5.24 → 0.5.25; re-enable per-collection workers on preprod

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -960,16 +960,17 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.24"
+    tag: "0.5.25"
     pullPolicy: Always
 
-  # 2026-06-23: CADENCE_PER_COLLECTION_WORKERS=true crashes at boot due
-  # to a connection storm — 147 collections × 1 fresh tokio_postgres
-  # connection each at the same moment overruns the PG connection limit
-  # and the pod hits liveness-probe failure before it can settle. Phase
-  # 1a needs a Semaphore concurrency cap before it's safe to enable.
-  # Tracked in a follow-up cadence PR. Until then preprod soaks the
-  # serial-mode 0.5.24 (still gets the poll-deadline + moka leak fixes).
+  # Phase 1a: per-collection watcher workers, throttled by the 0.5.25
+  # Semaphore cap (min(num_cpus*2, 16)) so the boot connection storm
+  # that crashlooped this pod on 2026-06-23 can't recur. Preprod-only
+  # soak until parallel mode is proven; prod stays serial-mode in this
+  # PR. See mycurelabs/monobase-mycure#1918 + #1922.
+  env:
+    - name: CADENCE_PER_COLLECTION_WORKERS
+      value: "true"
 
   replicaCount: 1
 

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1085,7 +1085,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.24"
+    tag: "0.5.25"
     pullPolicy: Always
 
   replicaCount: 1


### PR DESCRIPTION
## Summary

Bumps cadence to 0.5.25 in both deployments. Re-enables Phase 1a parallel-mode (`CADENCE_PER_COLLECTION_WORKERS=true`) on preprod, now safe thanks to the 0.5.25 Semaphore concurrency cap.

- Code PR: mycurelabs/monobase-mycure#1922 (merged)
- Image: ghcr.io/mycurelabs/cadence:0.5.25
- Previous attempt: monobase-infra#23 (caused preprod crashloop, reverted in #24)

## What 0.5.25 adds

Shared `tokio::sync::Semaphore` cap on per-collection watcher concurrency. Cap = `min(num_cpus * 2, 16)` via `std::thread::available_parallelism` (stdlib, no new dep).

Held across full poll → caps both boot connection storm AND steady-state concurrent PG connections.

## Verification

- [ ] Preprod cadence pod stays ready, no crashloop
- [ ] Log shows `starting per-collection PG watcher workers (Phase 1) count=146 concurrent_poll_cap=16`
- [ ] PG `pg_stat_activity` from cadence stays ≤ 16
- [ ] All ~146 baseline scans complete within ~10 min (vs sequential serial mode's many hours when one table is large)
- [ ] No `baseline connect failed` errors

## Rollback

Revert this PR — preprod reverts to 0.5.24 serial. Prod also reverts but they're functionally equivalent (prod doesn't use the parallel flag).