### PR TITLE
fix(medley): NetworkPolicy egress to ollama Service

### DIFF
--- a/charts/medley/values.yaml
+++ b/charts/medley/values.yaml
@@ -165,6 +165,8 @@ networkPolicy:
         - protocol: TCP
           port: 8920   # openmed in-cluster
         - protocol: TCP
+          port: 11434  # ollama egress Service (tailscale ns) — in-cluster pod needs namespaceSelector, not ipBlock
+        - protocol: TCP
           port: 53
         - protocol: UDP
           port: 53


### PR DESCRIPTION
ipBlock egress doesn't match in-cluster pod IPs → medley couldn't reach ollama.tailscale.svc:11434. Add 11434 to the namespaceSelector egress rule.