### PR TITLE
fix(infra): defensive nil guard on medley.yaml template (unblock prod sync)

### DIFF
--- a/argocd/applications/templates/medley.yaml
+++ b/argocd/applications/templates/medley.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.medley.enabled }}
+{{- if (.Values.medley | default dict).enabled }}
 # ArgoCD Application: Medley AI Gateway
 # Sync Wave 3 - Deploy after core services
 


### PR DESCRIPTION
**Hotfix.** PR #25 added \`argocd/applications/templates/medley.yaml\` using \`{{- if .Values.medley.enabled }}\`. Production's values file has no \`medley:\` block (preprod-only feature), so helm-template fails with \`nil pointer evaluating interface {}.enabled\` when the prod root-app re-renders. Caught during cadence 0.5.25 deploy (#27).

The other 3 sibling templates added in the same PR (\`medgemma-worker\`, \`medleyapp\`, \`openmed\`) already use \`(.Values.X | default dict).enabled\`. medley.yaml just missed it.

One-line fix, makes medley.yaml consistent with its siblings, unblocks prod sync.