### PR TITLE
chore(cadence): bump preprod memory to match prod (unblock parallel-mode soak)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -974,15 +974,19 @@ cadence:
 
   replicaCount: 1
 
-  # Resources matched to staging — the 0.5.x line's cursor-based baseline scan
-  # + paginated catch-up + batched change-log queries cap peak RSS <500MB.
+  # Resources match prod (4Gi limit / 1Gi request) so preprod can soak
+  # the per-collection-workers mode at realistic capacity. 2Gi here OOMed
+  # under the parallel watcher's per-task LRU allocations during boot
+  # baseline-scan (2026-06-23). Follow-up cadence PR will divide LRU
+  # capacity by num_collections in parallel mode, after which we can
+  # consider stepping preprod back down.
   resources:
     requests:
       cpu: 200m
-      memory: 512Mi
+      memory: 1Gi
     limits:
       cpu: "2"
-      memory: 2Gi
+      memory: 4Gi
 
   gateway:
     hostname: ""


### PR DESCRIPTION
Preprod cadence OOMed during per-collection-workers boot baseline-scan. 2 GiB wasn't enough headroom for 147 per-task LRU allocations. Bumping to prod-parity 4 GiB / 1 GiB. Follow-up cadence PR will divide per-task LRU by num_collections so we can step back down later.