### PR TITLE
deploy: medley 0.1.1 + medleyapp 0.1.2 to preprod (model-online indicator)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -494,7 +494,7 @@ medley:
 
   image:
     repository: ghcr.io/mycurelabs/medley
-    tag: "0.1.0"
+    tag: "0.1.1"
     pullPolicy: IfNotPresent
 
   replicaCount: 1
@@ -538,7 +538,7 @@ medleyapp:
 
   image:
     repository: ghcr.io/mycurelabs/medleyapp
-    tag: "0.1.1"
+    tag: "0.1.2"
     pullPolicy: IfNotPresent
 
   replicaCount: 1


### PR DESCRIPTION
Bumps preprod image tags for the model-online indicator feature.

- **medley** 0.1.0 → 0.1.1 — adds `GET /api/status` (no-auth Ollama reachability probe; independent of `/healthz`).
- **medleyapp** 0.1.1 → 0.1.2 — header status pill (online/idle/offline), offline banner, Stop button + elapsed timer while streaming.

Images already built + pushed to ghcr (verified `docker manifest inspect`). Child apps track `main`; after merge the **root** app needs a sync so the medley/medleyapp child `valuesObject` re-renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)