### PR TITLE
fix(preprod): openmed PVC storageClass do-block-storage

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -628,6 +628,7 @@ openmed:
   persistence:
     enabled: true
     size: 3Gi
+    storageClassName: do-block-storage  # DOKS CSI — the chart default 'longhorn' doesn't exist here
 
   podDisruptionBudget:
     enabled: false


### PR DESCRIPTION
openmed's 3Gi model-cache PVC defaulted to `longhorn` (chart fallback), which doesn't exist on DOKS → PVC Pending → pod unschedulable. Pin to `do-block-storage`. The stuck (empty, unbound) PVC will be deleted so Argo recreates it with the correct class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)