### PR TITLE
deploy: openmed 0.1.1 (transformers<5.12 fix) + Recreate strategy

### DIFF
--- a/charts/openmed/templates/deployment.yaml
+++ b/charts/openmed/templates/deployment.yaml
@@ -10,6 +10,11 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  # Recreate: openmed mounts a single ReadWriteOnce model-cache PVC, so two pods can never run at
+  # once — a RollingUpdate deadlocks (new pod can't attach the PVC the old pod still holds). Terminate
+  # the old pod before starting the new one.
+  strategy:
+    type: {{ .Values.strategy.type | default "Recreate" }}
   selector:
     matchLabels:
       {{- include "openmed.selectorLabels" . | nindent 6 }}

--- a/charts/openmed/values.yaml
+++ b/charts/openmed/values.yaml
@@ -16,6 +16,11 @@ enabled: true
 
 replicaCount: 1
 
+# Recreate — single ReadWriteOnce model-cache PVC means two pods can't coexist,
+# so a RollingUpdate would deadlock on PVC attach. Terminate old before new.
+strategy:
+  type: Recreate
+
 image:
   repository: ghcr.io/mycurelabs/openmed
   pullPolicy: IfNotPresent

--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -606,7 +606,7 @@ openmed:
 
   image:
     repository: ghcr.io/mycurelabs/openmed
-    tag: "0.1.0"
+    tag: "0.1.1"
     pullPolicy: IfNotPresent
 
   replicaCount: 1


### PR DESCRIPTION
Fixes the openmed crashloop from Phase 2. The 0.1.0 image resolved transformers 5.12.1, whose new deepgemm.py crashes torch 2.12 on import. 0.1.1 pins transformers<5.12 (→5.11.0). Also sets openmed to **Recreate** strategy (single RWO PVC → RollingUpdate deadlocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)