### PR TITLE
deploy: openmed 0.1.2 (pin torch<2.12)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -606,7 +606,7 @@ openmed:
 
   image:
     repository: ghcr.io/mycurelabs/openmed
-    tag: "0.1.1"
+    tag: "0.1.2"
     pullPolicy: IfNotPresent
 
   replicaCount: 1


### PR DESCRIPTION
0.1.1 still crashed — the dynamo cache double-registration is torch 2.12.x's bug, not transformers'. 0.1.2 pins torch<2.12 (→2.11.0); verified imports clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)