### PR TITLE
feat(cadence): PG-native changelog dual-write opt-in on preprod (Phase 3.2)

### DIFF
--- a/charts/cadence/templates/deployment.yaml
+++ b/charts/cadence/templates/deployment.yaml
@@ -103,6 +103,18 @@ spec:
         - name: CADENCE_VALKEY_URL
           value: "redis://:$(VALKEY_PASSWORD)@{{ include "cadence.valkey.host" . }}:{{ .Values.valkey.port | default 6379 }}"
         {{- end }}
+        # Phase 3 PG-native changelog. When enabled, cadence dual-writes
+        # changelog entries to both Valkey and a cadence-owned PG schema.
+        # `readFrom` selects the authoritative read source. Defaults the
+        # DSN to the hapihub PG (same DB; cadence writes its own schema).
+        {{- if (.Values.pgChangelog | default dict).enabled }}
+        - name: CADENCE_PG_CHANGELOG_URL
+          value: {{ default (printf "postgres://$(POSTGRESQL_USER):$(POSTGRESQL_PASSWORD)@%s:5432/%s" (include "cadence.postgresql.host" .) (include "cadence.postgresql.database" .)) .Values.pgChangelog.url | quote }}
+        - name: CADENCE_CHANGELOG_READ_FROM
+          value: {{ .Values.pgChangelog.readFrom | default "valkey" | quote }}
+        - name: CADENCE_CHANGELOG_RETENTION_DAYS
+          value: {{ .Values.pgChangelog.retentionDays | default 7 | quote }}
+        {{- end }}
         # Load secrets from External Secrets Operator
         {{- if .Values.externalSecrets.enabled }}
         {{- range .Values.externalSecrets.secrets }}

--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -248,6 +248,30 @@ valkey:
     existingSecret: "valkey"     # Bitnami chart creates this secret
     secretKey: "valkey-password"
 
+# Phase 3 (cadence 0.5.29+): PG-native partitioned changelog. When enabled,
+# cadence dual-writes every change-log entry to both Valkey and a
+# cadence-owned `cadence` schema in the same PG as `postgresql.*`. Valkey
+# remains authoritative until `readFrom: pg` is flipped after the preprod
+# soak. Off by default — opt in per-environment.
+#
+# See services/cadence README and mycurelabs/monobase-mycure#1947 for the
+# rollout playbook.
+pgChangelog:
+  enabled: false
+  # When enabled but `url` is empty, the deployment template defaults the
+  # DSN to the same hapihub PG (postgresql.* above). Set explicitly to
+  # point at a different host.
+  url: ""
+  # "valkey" (default — dual-write only) or "pg" (PG-authoritative reads).
+  # Only flip to "pg" after `dual_write_divergence_total = 0` across a
+  # multi-day soak.
+  readFrom: "valkey"
+  # Drop partitions older than this many days during daily maintenance.
+  # Aligned with the Valkey changelog retention; a peer offline longer
+  # reconnects via the below-trim-floor primary-reader snapshot path
+  # (shipped in 0.5.20).
+  retentionDays: 7
+
 # Service Monitor for Prometheus (if monitoring enabled)
 serviceMonitor:
   enabled: false

--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -1018,6 +1018,22 @@ cadence:
     enabled: true
     serviceName: "valkey-primary"
 
+  # Phase 3.2 (cadence 0.5.29+, mycurelabs/monobase-mycure#1947):
+  # PG-native partitioned changelog dual-write soak. Cadence writes every
+  # change-log entry to both Valkey and the cadence-owned PG schema in
+  # the same `hapihub` DB. Valkey remains authoritative (`readFrom:
+  # valkey`); the schema is created idempotently via refinery migrations
+  # at boot. Watch `dual_write_divergence_total` — must stay at 0 across
+  # the 5-day soak before flipping `readFrom: pg` in a follow-up PR.
+  #
+  # No risk to current sync: if PG is unreachable the dual-write side
+  # fails open (Valkey writes succeed, divergence counter increments,
+  # WARN logged). Requires cadence image tag >= 0.5.29.
+  pgChangelog:
+    enabled: true
+    readFrom: "valkey"
+    retentionDays: 7
+
   config:
     RUST_LOG: "info"
 

--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -974,7 +974,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.26"
+    tag: "0.5.29"
     pullPolicy: Always
 
   # Phase 1a: per-collection watcher workers, throttled by the 0.5.25


### PR DESCRIPTION
Stacked behind cadence 0.5.29 (mono PRs mycurelabs/monobase-mycure#1943 and mycurelabs/monobase-mycure#1947). **Do not merge until those land and the 0.5.29 image is published.**

## Summary

- Adds `pgChangelog: { enabled, url, readFrom, retentionDays }` to the cadence chart's `values.yaml` (default off).
- Adds the conditional env block to `templates/deployment.yaml` — emits `CADENCE_PG_CHANGELOG_URL` / `CADENCE_CHANGELOG_READ_FROM` / `CADENCE_CHANGELOG_RETENTION_DAYS` when enabled. DSN defaults to the chart's `postgresql.*` (same hapihub DB; cadence writes its own `cadence` schema).
- Flips `cadence.pgChangelog.enabled = true` on preprod (`readFrom: valkey`, `retentionDays: 7`).

## Render check
- Off by default (no opt-in values) → no PG env emitted.
- `--set pgChangelog.enabled=true` → emits all three env vars with the inferred hapihub DSN. ✓

## Soak gate before Phase 3.3 (read flip)
- `dual_write_divergence_total` metric must stay at 0 across 5+ days.
- Daily `cadence.changelog_yYYYYmMMdDD` partitions visible in `pg_inherits`.
- Hourly `PG changelog maintenance` INFO logs.

## Failure-mode contract
PG unreachable mid-run: Valkey writes still succeed, PG side logs WARN, divergence counter increments. Sync degradation requires Valkey + PG both down — no worse than today.

## Tag bump
Lands in the same merge (bump preprod cadence `image.tag` 0.5.26 → 0.5.29) or a fast follow-up once CI publishes the image.

## Test plan
- [x] `helm template charts/cadence` — default off, no PG env
- [x] `helm template charts/cadence --set pgChangelog.enabled=true` — emits all three env vars with inferred DSN
- [ ] After merge + image bump: deploy to preprod, watch `dual_write_divergence_total` for 5 days
- [ ] Verify `cadence.changelog` schema + daily partitions land via `psql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)