### PR TITLE
deploy: openmed 0.1.3 (torch<2.8)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -606,7 +606,7 @@ openmed:
 
   image:
     repository: ghcr.io/mycurelabs/openmed
-    tag: "0.1.2"
+    tag: "0.1.3"
     pullPolicy: IfNotPresent
 
   replicaCount: 1


### PR DESCRIPTION
torch 2.11/2.12 crash on the DOKS nodes (mega-cache precompile double-registration). 0.1.3 pins torch<2.8 (→2.7.1), predating that module. 🤖 Generated with [Claude Code](https://claude.com/claude-code)