### PR TITLE
fix(openmed): enableServiceLinks false

### DIFF
--- a/charts/openmed/templates/deployment.yaml
+++ b/charts/openmed/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
       labels:
         {{- include "openmed.selectorLabels" . | nindent 8 }}
     spec:
+      # Disable the legacy Docker-link service env vars: the `openmed` Service otherwise injects
+      # OPENMED_PORT=tcp://<clusterIP>:8920, clobbering the app's own OPENMED_PORT=8920 (config.py
+      # does int(OPENMED_PORT) → ValueError). openmed uses DNS, not these vars. Matches hapihub.
+      enableServiceLinks: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
openmed Service injects OPENMED_PORT=tcp://… clobbering the app's OPENMED_PORT=8920 → ValueError crashloop. Disable Docker-link service env (uses DNS). 🤖 Generated with [Claude Code](https://claude.com/claude-code)