### PR TITLE
deploy(cadence): un-stall prod from baseline-scan crashloop (0.5.32 + parallel mode)

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1111,8 +1111,22 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.26"
+    tag: "0.5.32"
     pullPolicy: Always
+
+  # Phase 1 fix: spawn one watcher task per collection so a slow
+  # baseline scan of any single table (e.g. analytics-daily-counts
+  # at 763k rows + 60s deadline) doesn't trigger the 10-consecutive-
+  # failures process-exit. Without this, prod has been restart-looping
+  # every ~10min (verified 2026-06-24: 19 restarts in 3h18m, exit
+  # reason "Watcher: 10 consecutive failures, exiting process").
+  # Throttled by the 0.5.25 Semaphore cap (min(num_cpus*2, 16)) so
+  # the boot connection storm that crashlooped preprod on 2026-06-23
+  # can't recur. Same env is live on preprod since 2026-06-23 with
+  # zero issues.
+  env:
+    - name: CADENCE_PER_COLLECTION_WORKERS
+      value: "true"
 
   replicaCount: 1
 


### PR DESCRIPTION
## Why

Prod cadence has been crashlooping every ~10min for the last 3h+:

\`\`\`
2026-06-24 08:38 UTC — 19 restarts on current pod
Exit reason: "Watcher: 10 consecutive failures, exiting process"
\`\`\`

Root cause: serial-mode baseline scan of large tables (analytics-daily-counts at 763k rows, billing-invoice-agts at 300k) busts the 60s per-poll deadline, the consecutive_failures counter trips 10, runtime self-exits as designed.

## Fix

Two minimal changes:

1. **Tag 0.5.26 → 0.5.32** — picks up Phase 1 connection-storm fixes (0.5.25), per-task LRU sizing (0.5.26), Phase 2 moka tracker (0.5.27), and Phase 5/6.0 refactors (no-op when pgChangelog off).
2. **CADENCE_PER_COLLECTION_WORKERS=true** — Phase 1's parallel watcher. One slow table can't starve every other table's polling.

## Soak proof

Same env + tag is live on preprod since 2026-06-23. ~1 day under real traffic, zero crashloops, lamport clock advancing through 4.5M ops cleanly.

## What's NOT in this PR

\`pgChangelog\` deliberately stays OFF on prod. That's **Phase 3.4** — gated on preprod's \`readFrom: pg\` flip (this run's sibling PR) soaking for >24h first.

## Rollback

Revert this commit; ArgoCD root-app sync; pod rolls back to 0.5.26 and the crashloop returns (no worse than now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)