### PR TITLE
chore(preprod): bump hapihub 11.20.22 → 11.20.23 (ship medical-AI features)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -182,7 +182,7 @@ hapihub:
 
   image:
     repository: ghcr.io/mycurelabs/hapihub
-    tag: "11.20.22"
+    tag: "11.20.23"
     pullPolicy: IfNotPresent
 
   replicaCount: 1


### PR DESCRIPTION
Bumps preprod hapihub to `11.20.23`, the first image built after the medical-AI merge (mono #1558 / version bump #1973). Includes `suggest-icd10`, document-ingestion, and `/document-search` — all 404 on the current `11.20.22` image. Required to verify #1550 / #1827 end-to-end on preprod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)