### PR TITLE
deploy(cadence): enable pgChangelog dual-write on prod (Phase 3.4)

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1166,6 +1166,28 @@ cadence:
     enabled: true
     serviceName: "valkey-primary"
 
+  # Phase 3.4: opt prod into the PG-native partitioned changelog. Dual-
+  # write soak — Valkey stays authoritative for reads (`readFrom:
+  # valkey`); cadence writes every change-log entry to BOTH stores so
+  # PG's `cadence` schema fills with parity data. Once the prod
+  # divergence counter holds at 0 for >5 days AND preprod's `readFrom:
+  # pg` flip has soaked for >24h, a follow-up PR flips this to "pg" too.
+  #
+  # Motivation: today (2026-06-24 09:36 UTC) prod cadence OOM-cycled
+  # the Valkey instance — pressure 3071/3072 MB, emergency trim 100k
+  # entries, append_change script failures cascaded, pod restarted.
+  # That's the exact failure mode Phase 3 targets. Enabling dual-write
+  # gets PG-backed durability in place; Phase 4 eventually removes
+  # the Valkey changelog write path entirely.
+  #
+  # Failure mode: if PG is unreachable, Valkey writes still succeed
+  # and `cadence:dual_write_divergence_total` on /metrics increments.
+  # Sync is never blocked by a PG outage during this phase.
+  pgChangelog:
+    enabled: true
+    readFrom: "valkey"
+    retentionDays: 7
+
   config:
     RUST_LOG: "info"
 


### PR DESCRIPTION
**Brought forward in response to a live incident.** Prod cadence OOMed Valkey at 2026-06-24 09:36 UTC after the parallel-mode rollout (infra#46) increased changelog write rate. Pressure ratio hit 0.9999 (3071/3072 MB), emergency trim deleted 100k entries but couldn't keep up, append_change Lua failures cascaded, OOMKilled exit 137. This is the exact failure mode Phase 3 was designed to fix.

## What this PR enables

\`\`\`yaml
cadence.pgChangelog:
  enabled: true
  readFrom: "valkey"  # Valkey stays read-authoritative; dual-write only
  retentionDays: 7    # daily DROP PARTITION trims; no Lua, no Valkey pressure on PG side
\`\`\`

## Risk profile

Identical to preprod's 2026-06-24 02:45 UTC soak — 6h on 4.5M ops with \`dual_write_divergence_total\` at 0.

## Failure mode

PG unreachable → Valkey writes still succeed, counter increments, WARN logged. **Sync is never blocked by a PG outage during this phase.**

## Gates for follow-up phases

- **Phase 3.5** (prod \`readFrom: pg\`): needs (a) prod divergence counter at 0 for >5 days, AND (b) preprod's \`readFrom: pg\` (infra#45) soaking for >24h
- **Phase 4** (delete Valkey changelog code paths): needs prod on \`readFrom: pg\` for >7 days

## Rollback

Revert this commit; ArgoCD root-app sync; cadence reverts to Valkey-only. The Valkey OOM cycle returns but is otherwise the same as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)