### PR TITLE
deploy(cadence): flip prod readFrom to pg (Phase 3.5)

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1183,9 +1183,18 @@ cadence:
   # Failure mode: if PG is unreachable, Valkey writes still succeed
   # and `cadence:dual_write_divergence_total` on /metrics increments.
   # Sync is never blocked by a PG outage during this phase.
+  # Phase 3.5: flip prod changelog reads to PG-authoritative.
+  # Empirical soak (2026-06-24 → 2026-06-25):
+  #   - preprod readFrom=pg ran 16h on 7.6M ops, 0 divergence, 0 restarts
+  #   - prod dual-write (readFrom=valkey) ran 14h on 548k ops, 0 divergence
+  #   - PG `cadence.changelog` has 770k+ rows, daily partitions rolling
+  # Writes still dual-write so Valkey stays as the seq allocator +
+  # rollback ground truth. Phase 4 removes the Valkey changelog write
+  # path entirely once readFrom=pg has soaked enough that we're
+  # comfortable.
   pgChangelog:
     enabled: true
-    readFrom: "valkey"
+    readFrom: "pg"
     retentionDays: 7
 
   config:


### PR DESCRIPTION
One-line flip: \`readFrom: \"valkey\"\` → \`\"pg\"\` on prod.

## Soak gates (compressed)

- preprod \`readFrom=pg\` since 2026-06-24 08:43 UTC — **16h on 7.6M ops, 0 divergence, 0 restarts**
- prod dual-write since 2026-06-24 10:02 UTC — **14h on 548k ops, 0 divergence**
- prod PG \`cadence.changelog\` table: **770k+ rows, 3 daily partitions rolling on schedule**
- Valkey recovered + healthy post AOF surgery

## What changes

Reads route to PG via the methods migrated in Phase 3.1b. Writes still dual-write so Valkey stays as seq allocator + rollback ground truth.

## Revert

One-line YAML revert + Argo sync. Reads fall back to Valkey within a pod boot.

## Phase 4 trigger

Observe \`/metrics\` for tens of minutes post-deploy. If divergence stays 0 and no read-side errors in logs, ship Phase 4 (delete Valkey changelog write path entirely + drop \`--maxmemory\` extraFlags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)