### PR TITLE
deploy(cadence): bump prod 0.5.32 → 0.5.36 (Phase 4a)

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1111,7 +1111,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.32"
+    tag: "0.5.36"
     pullPolicy: Always
 
   # Phase 1 fix: spawn one watcher task per collection so a slow


### PR DESCRIPTION
0.5.36 (mycurelabs/monobase-mycure#1988) stops the Valkey changelog Lua write entirely when \`readFrom=pg\`. Removes the write-side load that drove the 2026-06-24 09:36 UTC Valkey OOM + several AOF corruption recoveries since.

## Behavior in prod

- \`append_change\`: PG write becomes load-bearing
- Valkey gets only seq INCR + non-changelog ops (peer tokens, JWKS cache, watermarks, catchup checkpoints, local identity) — orders of magnitude less write traffic
- \`start_changelog_trim_task\` no longer spawns (nothing to trim Valkey-side)

## Trade-off

Write path coupled to PG availability. PG is HA via streaming replication, strictly more reliable than the standalone Valkey we've been recovering all night. Acceptable.

## Rollback

Revert this commit; prod returns to 0.5.32. The Valkey OOM cycle eventually returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)