### PR TITLE
fix(hapihub): route /device-telemetry on v10 host to hapihub-next

### DIFF
--- a/charts/hapihub/templates/storage-route.yaml
+++ b/charts/hapihub/templates/storage-route.yaml
@@ -1,12 +1,16 @@
 {{- /*
-Optional extra HTTPRoute that points /storage on a (legacy) hostname at THIS
-release's service. Used by hapihub-next (issue #44): storage/file/link URLs are
-minted from EXTERNAL_ADDRESS, which for hapihub-next resolves to the v10 host
-(hapihub.<domain>). EXTERNAL_ADDRESS is ALSO better-auth's baseURL, so it can't
-be changed without breaking auth. Routing only /storage on that host to this v11
-service fixes the URLs without touching EXTERNAL_ADDRESS. The v10 release serves
-no /storage traffic on that host, so this is non-disruptive (more-specific path
-match wins over the v10 route's PathPrefix: /).
+Optional extra HTTPRoute that points specific path prefixes on a (legacy)
+hostname at THIS release's service. Used by hapihub-next (issue #44): clients
+and minted URLs target EXTERNAL_ADDRESS, which for hapihub-next resolves to the
+v10 host (hapihub.<domain>). EXTERNAL_ADDRESS is ALSO better-auth's baseURL, so
+it can't be changed without breaking auth. Routing only the v11-only paths on
+that host to this v11 service fixes them without touching EXTERNAL_ADDRESS.
+
+Paths default to [/storage]; mycure-production also adds /device-telemetry so
+maestroapp installs (whose sync-token iss + VITE_API_SERVER both point at the
+v10 host) can reach the device-telemetry service that lives only on v11. The
+v10 release serves none of these paths on that host, so this is non-disruptive
+(more-specific path match wins over the v10 route's PathPrefix: /).
 */ -}}
 {{- if and .Values.enabled .Values.gateway.storageRoute .Values.gateway.storageRoute.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
@@ -27,9 +31,11 @@ spec:
     {{- end }}
   rules:
     - matches:
+        {{- range .Values.gateway.storageRoute.paths | default (list "/storage") }}
         - path:
             type: PathPrefix
-            value: /storage
+            value: {{ . }}
+        {{- end }}
       backendRefs:
         - name: {{ include "hapihub.fullname" . }}
           port: {{ .Values.service.port }}

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -374,6 +374,13 @@ hapihubNext:
       sectionName: https-lfh
       hostnames:
         - hapihub.localfirsthealth.com
+      # v11-only paths to forward from the v10 host to hapihub-next.
+      # /device-telemetry: maestroapp installs' sync-token iss + VITE_API_SERVER
+      # both point at the v10 host, but the device-telemetry service lives only
+      # on v11. v10 returns 404 for these paths, so forwarding is non-disruptive.
+      paths:
+        - /storage
+        - /device-telemetry
 
   betterAuth:
     passkey:


### PR DESCRIPTION
## What
Generalizes the existing `/storage` shim (#44) so the v10 host `hapihub.localfirsthealth.com` forwards a configurable list of **v11-only path prefixes** to the `hapihub-next` service, and adds `/device-telemetry` alongside `/storage` in `mycure-production`.

## Why
`device-telemetry` lives only on hapihub-next (v11, Postgres). maestroapp installs target the v10 host for everything — their Cadence sync-token `iss` **and** baked `VITE_API_SERVER` both resolve to `hapihub.localfirsthealth.com` — but v10 returns **404** for `/device-telemetry`, so the fleet can't enroll into telemetry.

Verified from a client box:
- `hapihub.localfirsthealth.com/device-telemetry/devices` → `404 NotFound`
- `hapihub-next.localfirsthealth.com/device-telemetry/devices` → `400` (route exists, validating)

## Safety
v10 serves none of these paths on that host, so forwarding is non-disruptive — more-specific path match wins over v10's `PathPrefix: /`. Same zero-auth-impact mechanism as the `/storage` fix; `EXTERNAL_ADDRESS` / better-auth baseURL untouched.

`paths` defaults to `[/storage]`, so no other deployment changes behavior. Rendered + verified with `helm template`.

Refs mycurelabs/monobase-mycure#1982 (maestroapp client fix: mycurelabs/monobase-mycure#1987)

🤖 Generated with [Claude Code](https://claude.com/claude-code)