### PR TITLE
deploy(valkey): drop --maxmemory + noeviction extraFlags (preprod + prod)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -872,14 +872,11 @@ valkey:
       limits:
         cpu: 500m
         memory: 2Gi
-    # Cap at 75% of container memory limit (1.5 GiB of 2 GiB). Pairs with
-    # cadence 0.5.21's memory-aware trim: when valkey returns OOM,
-    # append_change retries with backoff and the trim task escalates.
-    extraFlags:
-      - "--maxmemory"
-      - "1610612736"  # 1.5 GiB
-      - "--maxmemory-policy"
-      - "noeviction"
+    # `--maxmemory 1.5GB` + `noeviction` dropped 2026-06-25 alongside
+    # the prod drop — cadence Phase 4a (0.5.36) stopped Valkey changelog
+    # writes when readFrom=Pg, so the cap that paired with the trim
+    # escalation policy is obsolete. Container memory limit (2 GiB)
+    # is the new ceiling.
 
 # ===== STORAGE: MinIO Object Storage =====
 minio:

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1012,20 +1012,17 @@ valkey:
       limits:
         cpu: 1000m
         memory: 4Gi
-    # 2026-06-22: cap valkey at 80% of container limit (3.2 GiB of 4 GiB)
-    # with `noeviction`. Once cadence 0.5.21 is wired up, hitting this cap
-    # produces `OOM command not allowed when used_memory > 'maxmemory'` on
-    # writes — which cadence catches in `append_change`, retries with
-    # backoff, and uses to drive the memory-aware trim task's emergency
-    # mode. Without this cap, valkey grows unbounded inside the container
-    # until the k8s SIGKILL (exitCode 137) kicks in mid-AOF-replay and
-    # we cycle into LOAD→OOM→LOAD. With this cap, OOM becomes app-
-    # observable and recoverable. See cadence 0.5.21 + monobase-mycure#1543.
-    extraFlags:
-      - "--maxmemory"
-      - "3221225472"  # 3 GiB (75% of 4 GiB limit; gives ~1 GiB AOF-rewrite headroom)
-      - "--maxmemory-policy"
-      - "noeviction"
+    # `--maxmemory 3GB` + `noeviction` dropped 2026-06-25 after cadence
+    # 0.5.36 (Phase 4a, mycurelabs/monobase-mycure#1988) stopped writing
+    # the Valkey changelog when readFrom=Pg. Without changelog writes,
+    # Valkey's working set is the seq counter + peer tokens + JWKS cache
+    # + watermarks — under 100 MiB at prod load. The 3 GiB cap was
+    # triggering false OOM-as-policy events (2026-06-24 09:36 UTC
+    # incident) before the container's k8s limit became relevant. Let
+    # the container limit do the actual ceiling now; if Valkey ever
+    # gets near 4 GiB again something is seriously wrong (changelog
+    # writes back on, or a new dataset class arrived) and we want a
+    # real signal, not an artificial OOM cycle.
 
 # ===== STORAGE: MinIO Object Storage =====
 minio:


### PR DESCRIPTION
Cadence Phase 4a (mycurelabs/monobase-mycure#1988, 0.5.36) stopped writing the Valkey changelog when \`readFrom=Pg\`. Without changelog writes, Valkey's working set is the seq counter + peer tokens + JWKS cache + watermarks — **under 100 MiB at prod load**.

The 3 GiB cap was triggering false OOM-as-policy events: today's 09:36 UTC incident was Valkey hitting the artificial 3 GiB, not the 4 GiB container limit. AOF chain corrupted, required surgical recovery (see \`feedback_valkey_aof_recovery_drill\`).

## What changes

| env | before | after |
|---|---|---|
| preprod | \`--maxmemory 1.5GB --maxmemory-policy noeviction\` | dropped; 2 GiB container limit |
| prod | \`--maxmemory 3GB --maxmemory-policy noeviction\` | dropped; 4 GiB container limit |

## Rollback

Revert this commit. Won't reproduce the OOM as long as cadence stays on 0.5.36+ with \`readFrom=Pg\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)