### PR TITLE
deploy(cadence): bump preprod + prod to 0.5.37 (Phase 4b + 6.3 cleanup)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -971,7 +971,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.29"
+    tag: "0.5.37"
     pullPolicy: Always
 
   # Phase 1a: per-collection watcher workers, throttled by the 0.5.25

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1115,7 +1115,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.36"
+    tag: "0.5.37"
     pullPolicy: Always
 
   # Phase 1 fix: spawn one watcher task per collection so a slow


### PR DESCRIPTION
Pure cleanup — no behavior change vs current tag.

| env | from | to |
|---|---|---|
| preprod | 0.5.29 | 0.5.37 |
| prod | 0.5.36 | 0.5.37 |

## What 0.5.37 contains

- **Phase 4b**: deletes the dormant Valkey changelog trim machinery (TRIM_SCRIPT Lua, trim_script field, start_changelog_trim_task fn, trim_changes_below_seq + memory_info impls)
- **Phase 6.3**: routes Iroh accept_loop through IrohTransport::accept + handle_incoming_conn (same shape WS uses)
- Net: -301 / +36 LOC

## Zero behavior change

Everything 4b deleted was already gated off in prod by Phase 4a (readFrom=Pg). 6.3 swaps the QUIC accept internals — session lifecycle unchanged. Session-key prefix changes "in:quic:N" → "in:iroh:N" in logs (cosmetic).

## Rollback

Revert this commit; tag returns to current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)