### PR TITLE
deploy(cadence): rollback prod 0.5.37 → 0.5.36 (startup hang)

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1115,7 +1115,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.37"
+    tag: "0.5.36"
     pullPolicy: Always
 
   # Phase 1 fix: spawn one watcher task per collection so a slow


### PR DESCRIPTION
0.5.37 prod rollout hangs pre-tracing-init. New pod stuck in \`futex_wait_queue\` with empty stdout, dies to liveness probe SIGKILL after ~45s. Old 0.5.36 pod stays Ready and serves traffic — **no user impact**.

## Why 0.5.36 → 0.5.37 → 0.5.36 (not just leave 0.5.37 broken)

ArgoCD selfHeal will keep retrying the 0.5.37 deploy. Rolling back the tag pins desired-state at 0.5.36 so the old healthy pod isn't churned.

## Preprod stays on 0.5.37

Preprod took the bump fine. We'll investigate prod-specific cause there.

## Open question

Phase 4b (deletes) + Phase 6.3 (IrohTransport migration) — neither should change init order. Suspected: race with Iroh endpoint init at prod peer-count. Needs offline repro with verbose tracing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)