### PR TITLE
deploy(cadence): cap statement_timeout=10s on prod PG-changelog connections

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1202,6 +1202,25 @@ cadence:
     enabled: true
     readFrom: "pg"
     retentionDays: 7
+    # 2026-06-26 ops mitigation: cap statement_timeout=10s on cadence's
+    # PG-changelog connections to bound the worst-case query duration.
+    # `max_lamports_by_doc_for_collection` was running 11+ minutes on
+    # the 78GB d25 partition even with a covering index (it scans the
+    # full collection's lamport history per call, ~830 calls/sec under
+    # peer-reconnect churn), pool-saturating and triggering Phase 4a's
+    # load-bearing `append_change` to fail (~42 errors / 60 min observed).
+    # With this timeout PG kills the slow query at 10s; cadence's existing
+    # fallback ("max_lamports_by_doc_for_collection failed; falling back
+    # to lamport=1") kicks in. Pool drains; appends succeed.
+    #
+    # Side effect: primary-DB-replayed rows get stamped lamport=1, so they
+    # always lose LWW vs peer-originated changes. Acceptable during
+    # catchup — peers' writes are expected to win against historical
+    # primary-DB baseline rows.
+    #
+    # URL template overrides the chart default. `options=-c%20...` is
+    # libpq's per-connection settings syntax (URL-encoded space + equals).
+    url: "postgres://$(POSTGRESQL_USER):$(POSTGRESQL_PASSWORD)@postgresql-primary.mycure-production.svc.cluster.local:5432/hapihub?options=-c%20statement_timeout%3D10000"
 
   config:
     RUST_LOG: "info"


### PR DESCRIPTION
Ops band-aid for the live degradation observed 2026-06-26: ~42 PG-authoritative append failures per hour because \`max_lamports_by_doc_for_collection\` takes 11+ minutes per call on the 78GB d25 partition (even with the covering index I just added). Pool saturates, Phase 4a's load-bearing append fails.

## What this changes

Adds \`options=-c%20statement_timeout%3D10000\` to cadence's PG-changelog connection URL only. PG kills any cadence query exceeding 10s; cadence's existing fallback path ("falling back to lamport=1") kicks in.

## Targeted scope

URL override only applies to cadence's PG-changelog pool. Hapihub's connections use a separate URL — unaffected.

## Side effect

Primary-DB-replayed rows get stamped lamport=1 → always lose LWW vs peer-originated changes. Acceptable during catchup since peers' writes should win against historical primary-DB baseline rows.

## Why not a real fix

Real fix = cache lamport_map per peer-session in Rust → image build + deploy. Carries 0.5.37 startup hang risk on prod. This URL change is pure ops + immediate.

## Rollback

Revert this commit; PG-changelog URL returns to default; slow query path returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)