### PR TITLE
Revert "deploy(cadence): cap statement_timeout=10s on prod PG-changelog connections"

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1202,25 +1202,6 @@ cadence:
     enabled: true
     readFrom: "pg"
     retentionDays: 7
-    # 2026-06-26 ops mitigation: cap statement_timeout=10s on cadence's
-    # PG-changelog connections to bound the worst-case query duration.
-    # `max_lamports_by_doc_for_collection` was running 11+ minutes on
-    # the 78GB d25 partition even with a covering index (it scans the
-    # full collection's lamport history per call, ~830 calls/sec under
-    # peer-reconnect churn), pool-saturating and triggering Phase 4a's
-    # load-bearing `append_change` to fail (~42 errors / 60 min observed).
-    # With this timeout PG kills the slow query at 10s; cadence's existing
-    # fallback ("max_lamports_by_doc_for_collection failed; falling back
-    # to lamport=1") kicks in. Pool drains; appends succeed.
-    #
-    # Side effect: primary-DB-replayed rows get stamped lamport=1, so they
-    # always lose LWW vs peer-originated changes. Acceptable during
-    # catchup — peers' writes are expected to win against historical
-    # primary-DB baseline rows.
-    #
-    # URL template overrides the chart default. `options=-c%20...` is
-    # libpq's per-connection settings syntax (URL-encoded space + equals).
-    url: "postgres://$(POSTGRESQL_USER):$(POSTGRESQL_PASSWORD)@postgresql-primary.mycure-production.svc.cluster.local:5432/hapihub?options=-c%20statement_timeout%3D10000"
 
   config:
     RUST_LOG: "info"


### PR DESCRIPTION
Reverting infra#55. The URL-encoded \`?options=-c%20statement_timeout%3D10000\` form isn't being parsed correctly by tokio-postgres at startup — new pod hangs on PG connect before tracing init, never opens port 7890, dies to liveness SIGKILL after 45s. Same symptom as the 0.5.37 startup hang.

Old 0.5.36 pod (no URL change) stays 1/1 Ready throughout — **no user impact** during the failed rollout.

## Next attempt

Real fix needs either:
- Different URL syntax (literal spaces, not URL-encoded) — needs testing
- Code change to call \`SET statement_timeout = 10000\` post-connect (more reliable)
- Or fall back to the structural fix (cache lamport_map per peer-session in Rust)

Investigation deferred to a fresh session.