### PR TITLE
deploy(hapihub-next): bump prod 11.20.24 → 11.20.25

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -341,7 +341,7 @@ hapihubNext:
 
   image:
     repository: ghcr.io/mycurelabs/hapihub
-    tag: "11.20.24"
+    tag: "11.20.25"
     pullPolicy: IfNotPresent
 
   replicaCount: 3


### PR DESCRIPTION
Bumps `hapihubNext.image.tag` in `mycure-production` to **11.20.25**, shipping the device-telemetry changes:
- monobase-mycure#1993 — clear live-state snapshots when a device goes offline
- monobase-mycure#2011 — box-measured internet speed/latency (`netStatus`)

Image built via the Hapihub Release action (monobase-mycure#2012). The `net_status` column migration applies on boot via the runtime migrations bundle. Non-disruptive rolling update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)