### PR TITLE
deploy(hapihub-next): bump prod 11.20.25 → 11.20.26

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -341,7 +341,7 @@ hapihubNext:
 
   image:
     repository: ghcr.io/mycurelabs/hapihub
-    tag: "11.20.25"
+    tag: "11.20.26"
     pullPolicy: IfNotPresent
 
   replicaCount: 3


### PR DESCRIPTION
Ships monobase-mycure#2015 — offline keeps last-known live-state (basis-date), reversing the brief #1993 clear-on-offline. Non-disruptive rolling update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)