### PR TITLE
feat(cadence): blacklist append-only history/archive + dedupe explicit collections

### DIFF
--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -137,12 +137,14 @@ cadenceConfig:
       strategy: lww
       scope_columns:
         user: id
-    personal_details:
+    # Use kebab-case for explicit entries; the wildcard resolver dedupes
+    # against snake_case (added in cadence 0.5.39, see monobase-mycure#2019).
+    personal-details:
       strategy: lww
       scope_columns:
         user: id
         organization: facility
-    personal_details_history:
+    personal-details-history:
       strategy: lww
       scope_columns:
         user: id
@@ -155,9 +157,17 @@ cadenceConfig:
     # collection. Skip entirely until pg_poll gets per-table parallelism or
     # timeouts. See monobase-mycure#1543 follow-up + memory project_cadence_0521_rollout_state.
     - "activity-logs"
+    # 2026-06-26: append-only tables don't need field-level CRDT sync.
+    # Glob support added in cadence 0.5.39 (monobase-mycure#2019).
+    # Re-logging every field of every row was the bulk of the 382M-row
+    # reseed that produced the 78 GB d25 partition.
+    - "*-history"             # personal-details-history, medical-records-history, ...
+    - "*-history-archive-*"   # *_history_archive_YYYYMMDD rotated snapshots
   # Per-collection sync priority (higher = sent first during catch-up).
   # "*" is the default for unlisted collections. Mirror of
   # services/hapihub/cadence.yml in monobase-mycure — keep in sync.
+  # Keys are kebab-case (the on-wire collection name); the applier path
+  # snake-converts internally for PG queries.
   priorities:
     "*": 50
     user: 200
@@ -165,53 +175,32 @@ cadenceConfig:
     session: 200
     accounts: 200
     account-configurations: 190
-    account_configurations: 190
     organization: 180
     organizations: 180
     organization-members: 170
-    organization_members: 170
-    personal_details: 180
-    personal_details_history: 170
     personal-details: 180
     personal-details-history: 170
     medical-patients: 150
-    medical_patients: 150
     medical-encounters: 140
-    medical_encounters: 140
     medical-records: 140
-    medical_records: 140
     medical-records-history: 130
-    medical_records_history: 130
     diagnostic-orders: 130
-    diagnostic_orders: 130
     diagnostic-order-tests: 130
-    diagnostic_order_tests: 130
     billing-invoices: 120
-    billing_invoices: 120
     billing-items: 110
-    billing_items: 110
     billing-payments: 110
-    billing_payments: 110
     billing-customers: 110
-    billing_customers: 110
     bookings: 90
     queue-items: 90
-    queue_items: 90
     queues: 90
     services: 80
     services-performeds: 80
-    services_performeds: 80
     notifications: 30
     prm-conversations: 30
-    prm_conversations: 30
     prm-messages: 30
-    prm_messages: 30
     webhook-deliveries: 20
-    webhook_deliveries: 20
     webhook-subscriptions: 20
-    webhook_subscriptions: 20
     activity-logs: 0
-    activity_logs: 0
 
 # Application configuration (ConfigMap env vars)
 config:


### PR DESCRIPTION
## Summary

Mirror of [monobase-mycure#2019](https://github.com/mycurelabs/monobase-mycure/pull/2019). Cadence 0.5.39 adds two fixes that this chart needs to take advantage of:

1. **Glob support in `is_blacklisted`** — add `*-history` and `*-history-archive-*` to `collectionsBlacklist` to stop logging append-only tables. These accounted for the bulk of the 382M-row reseed on 2026-06-25 that produced the 78 GB \`d25\` partition.

2. **Normalized wildcard-vs-explicit dedup** — convert explicit `personal_details` / `personal_details_history` entries to kebab-case and drop the snake aliases from `priorities`. The applier path snake-converts internally for PG queries.

## Behavior on current image tags

| Cadence tag | Effect of this PR |
|---|---|
| 0.5.36 (prod), 0.5.37 (preprod) | Glob entries are inert (exact-match falls back, no table named `*-history`). The kebab-only cleanup still helps: removes the dual-watch that doubled changelog volume for `personal-details` and `personal-details-history`. |
| 0.5.39+ (post-image-bump) | Full effect — glob blacklist drops `*_history_archive_YYYYMMDD` tables entirely. |

Tag bumps are intentionally **NOT** in this PR. Preprod stays on 0.5.37 as the repro env for the 0.5.37 prod startup hang until that issue is investigated.

## Test plan

- [x] Helm template renders cleanly (no env-level overrides of `cadenceConfig.collections` / `collectionsBlacklist` / `priorities` in any deployment values file).
- [ ] ArgoCD root-app sync of `mycure-preprod-root` + child `cadence-preprod` after merge.
- [ ] PG query against preprod after deploy confirms only one entry per collection name and no `*-history` / `*-history-archive-*` writes (after 0.5.39 tag bump in a follow-up):
  ```sql
  SELECT collection, count(*) FROM cadence.changelog
    WHERE created_at > NOW() - INTERVAL '1 hour'
    GROUP BY 1 ORDER BY 2 DESC LIMIT 20;
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)