### PR TITLE
chore(cadence): bump preprod to 0.5.39

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -971,7 +971,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.37"
+    tag: "0.5.39"
     pullPolicy: Always
 
   # Phase 1a: per-collection watcher workers, throttled by the 0.5.25


### PR DESCRIPTION
## Summary

Bump cadence on preprod from **0.5.37 → 0.5.39**. Image was just published by [Cadence Release run 28221577100](https://github.com/mycurelabs/monobase-mycure/actions/runs/28221577100).

0.5.39 (monobase-mycure#2019) ships:
- **Glob blacklist** support (`*-history`, `*-history-archive-*` now drop append-only tables — chart entries in monobase-infra#59 take effect on this tag).
- **Normalized wildcard-vs-explicit dedup** (snake/kebab explicit entries no longer dual-watch the same PG table; cleanup also belt-and-suspenders inside the binary).

## Prod is intentionally NOT bumped in this PR

Prod stays on **0.5.36**. The 0.5.37 prod-startup hang (see memory `project_cadence_0537_prod_startup_hang.md`) is still uninvestigated, and 0.5.39 inherits that risk. Prod tag bump is a follow-up after that's understood.

## Test plan

- [ ] ArgoCD sync of `mycure-preprod-root` → `cadence-preprod` after merge.
- [ ] `kubectl -n mycure-preprod get pod -l app=cadence` reaches Ready.
- [ ] PG query confirms the defect fixes are live:
  ```sql
  SELECT collection, count(*) FROM cadence.changelog
    WHERE created_at > NOW() - INTERVAL '1 hour'
    GROUP BY 1 ORDER BY 2 DESC LIMIT 20;
  ```
  - No `*-history` / `*-history-archive-*` rows.
  - No same-collection kebab+snake pairs.

## Cost

Burns the only 0.5.37 prod-startup-hang repro env. Acceptable per user direction; if needed we can spin a side preprod-clone later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)