### PR TITLE
revert(cadence): bump preprod back to 0.5.37

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -972,7 +972,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.39"
+    tag: "0.5.37"
     pullPolicy: Always
 
   # Phase 1a: per-collection watcher workers, throttled by the 0.5.25


### PR DESCRIPTION
Reverts #60. 0.5.39's V2 migration (plain CREATE INDEX) hangs forever on preprod's 70 GB d25 partition, gets SIGKILLed by 45 s liveness window, crashloops. Restore 0.5.37 (which has no V2) until I pre-build the index manually via CONCURRENTLY-per-partition (same pattern used on prod 2026-06-26).