### PR TITLE
chore(cadence): bump preprod to 0.5.39 (V2 index pre-built)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -972,7 +972,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.37"
+    tag: "0.5.39"
     pullPolicy: Always
 
   # Phase 1a: per-collection watcher workers, throttled by the 0.5.25


### PR DESCRIPTION
Re-bump after #61 rollback. V2's parent + 4 partition covering indexes were built manually via CONCURRENTLY (mirror of prod 2026-06-26 recipe). Refinery's CREATE INDEX IF NOT EXISTS at startup is now a sub-second no-op.