### PR TITLE
chore(cadence): bump prod 0.5.36 → 0.5.39, drop retentionDays 7 → 2

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1118,7 +1118,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.36"
+    tag: "0.5.39"
     pullPolicy: Always
 
   # Phase 1 fix: spawn one watcher task per collection so a slow
@@ -1202,7 +1202,10 @@ cadence:
   pgChangelog:
     enabled: true
     readFrom: "pg"
-    retentionDays: 7
+    # 2026-06-26: dropped 7→2 after the 158 GB d25 reseed event.
+    # Cost: peers offline >2 days fall below the lamport trim floor
+    # and must do a snapshot-based resume (existing code path).
+    retentionDays: 2
 
   config:
     RUST_LOG: "info"


### PR DESCRIPTION
**Disk emergency follow-up.** Prod PG hit 94 % disk under the 2026-06-25 reseed load. d25 (158 GB) dropped manually 09:30 UTC, freeing 158 GB (94 % → 37 %). This PR is the steady-state fix so it doesn't recur.

**0.5.39** ships glob blacklist + dual-emit dedup (mono#2019). The chart blacklist entries `*-history` and `*-history-archive-*` (monobase-infra#59) were inert on 0.5.36 because exact-match — 0.5.39 makes them work. That drops ~38 % of current writes:

| Collection | rows/5 min |
|---|---|
| medical-records-history | 496 k |
| personal-details-history | 477 k |
| medical-records-history-archive-20260422 | 332 k |
| inventory-stocks-history-archive-20260422 | 36 k |

**V2 migration safety**: prod's parent index `changelog_collection_doc_lamport_idx` was pre-built 2026-06-26 09:20 UTC with d24/d26/d27 children attached. Refinery's `CREATE INDEX IF NOT EXISTS` is now a sub-second no-op at startup — same as the verified preprod deploy 08:48 UTC.

**retentionDays 7 → 2**: caps recoverable bloat at 2 days. A repeat reseed auto-drops in 2 days instead of 7. Cost: peers offline >2 days pay for a snapshot-based resume on reconnect (existing code path).

## Test plan
- [ ] ArgoCD root + child sync.
- [ ] New pod READY without restart; refinery records V2.
- [ ] PG query confirms history/archive collections stop accumulating:
```sql
SELECT collection, count(*) FROM cadence.changelog
WHERE created_at > NOW() - INTERVAL '5 minutes'
  AND (collection LIKE '%-history' OR collection LIKE '%-history-archive-%')
GROUP BY 1 ORDER BY 2 DESC LIMIT 10;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)