### PR TITLE
chore(cadence): bump preprod + prod 0.5.39 → 0.5.40

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -972,7 +972,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.39"
+    tag: "0.5.40"
     pullPolicy: Always
 
   # Phase 1a: per-collection watcher workers, throttled by the 0.5.25

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1118,7 +1118,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.5.39"
+    tag: "0.5.40"
     pullPolicy: Always
 
   # Phase 1 fix: spawn one watcher task per collection so a slow


### PR DESCRIPTION
0.5.40 (mono#2030 / closes mono#2029) makes the blacklist also prune explicit `cadenceConfig.collections` entries. Previously the blacklist only filtered wildcard-discovered tables; explicit entries like `personal-details-history` (kept for `scope_columns`) bypassed it and were still writing ~28 GB/day to the changelog on prod 0.5.39 (measured 06-26 15:30 UTC).

Both envs are already on 0.5.39 with V2 index pre-built, so 0.5.40 boots clean (sub-second refinery no-op). Verification post-deploy: `personal-details-history` rows should drop to 0 in `SELECT collection, count(*) FROM cadence.changelog WHERE created_at > NOW() - INTERVAL '5 minutes' AND collection LIKE '%-history' GROUP BY 1`.