### PR TITLE
feat(artifacts-store): public-read MinIO for desktop releases at artifacts.localfirsthealth.com

### DIFF
--- a/argocd/applications/templates/database-secrets.yaml
+++ b/argocd/applications/templates/database-secrets.yaml
@@ -33,6 +33,10 @@ spec:
         # ExternalSecret where MinIO is disabled (e.g. prod uses GCS, no GCP key).
         minio:
           enabled: {{ if .Values.minio }}{{ .Values.minio.enabled | default false }}{{ else }}false{{ end }}
+        # Forward minio-artifacts.enabled so the minio-artifacts-credentials
+        # ExternalSecret is only created where the artifacts store runs (prod).
+        minioArtifacts:
+          enabled: {{ if (index .Values "minio-artifacts") }}{{ (index .Values "minio-artifacts").enabled | default false }}{{ else }}false{{ end }}
 
   destination:
     server: https://kubernetes.default.svc

--- a/argocd/applications/templates/minio-artifacts.yaml
+++ b/argocd/applications/templates/minio-artifacts.yaml
@@ -64,6 +64,28 @@ spec:
             extraCommands:
               - mc mb --ignore-existing provisioning/artifacts
               - mc anonymous set download provisioning/artifacts
+            # Least-privilege publisher policy + user for CI. CI authenticates
+            # with THIS scoped user (PutObject/GetObject on the artifacts bucket),
+            # never the MinIO root creds — so a leaked CI key can't reach admin,
+            # other buckets, or delete objects. The password is sourced from the
+            # minio-artifacts-ci secret (ExternalSecret), never plaintext in git.
+            policies:
+              - name: minio-artifacts-publisher
+                statements:
+                  - effect: "Allow"
+                    resources:
+                      - "arn:aws:s3:::artifacts"
+                    actions:
+                      - "s3:ListBucket"
+                      - "s3:GetBucketLocation"
+                  - effect: "Allow"
+                    resources:
+                      - "arn:aws:s3:::artifacts/*"
+                    actions:
+                      - "s3:PutObject"
+                      - "s3:GetObject"
+            usersExistingSecrets:
+              - minio-artifacts-ci
           persistence:
             enabled: true
             storageClass: {{ (index .Values "minio-artifacts").persistence.storageClass | default "" }}

--- a/argocd/applications/templates/minio-artifacts.yaml
+++ b/argocd/applications/templates/minio-artifacts.yaml
@@ -1,0 +1,138 @@
+{{- if (index .Values "minio-artifacts") }}
+{{- if (index .Values "minio-artifacts").enabled }}
+# ArgoCD Application: Artifacts Store (public-read MinIO)
+# Serves desktop-app release artifacts + Tauri auto-updater manifests at
+# artifacts.localfirsthealth.com. DEDICATED instance (not the per-client
+# `minio`) because this bucket is PUBLIC-read and global, so it must not share
+# an endpoint with the private monobase-files store.
+# Sync Wave 2 - Deploy storage before applications.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.global.namespace }}-minio-artifacts
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  ignoreDifferences:
+  - group: ""
+    kind: ServiceAccount
+    jsonPointers:
+    - /secrets
+    - /imagePullSecrets
+  - group: ""
+    kind: ConfigMap
+    jqPathExpressions:
+    - .data
+
+  sources:
+    # Source 1: Bitnami MinIO Helm chart (dedicated artifacts instance)
+    - chart: minio
+      repoURL: https://charts.bitnami.com/bitnami
+      targetRevision: 14.x.x
+      helm:
+        releaseName: minio-artifacts
+        valuesObject:
+          fullnameOverride: minio-artifacts
+          global:
+            security:
+              allowInsecureImages: true
+          image:
+            repository: {{ (index .Values "minio-artifacts").image.repository | default "bitnamilegacy/minio" }}
+            tag: {{ (index .Values "minio-artifacts").image.tag | default "2025.7.23-debian-12-r3" }}
+          mode: standalone
+          statefulset:
+            replicaCount: 1
+          # Virtual-host addressing: <bucket>.<MINIO_DOMAIN> -> bucket. Lets
+          # artifacts.<domain>/<key> serve the `artifacts` bucket with clean
+          # paths (no /bucket prefix) while keeping S3 SigV4 writes stable.
+          extraEnvVars:
+            - name: MINIO_DOMAIN
+              value: {{ .Values.global.domain }}
+          auth:
+            existingSecret: minio-artifacts
+          # Single public-read bucket. defaultBuckets creates it; provisioning
+          # flips it to anonymous-download (Tauri updater + browser downloads are
+          # unauthenticated GETs — no CORS needed, the Rust updater isn't a browser).
+          defaultBuckets: artifacts
+          provisioning:
+            enabled: true
+            extraCommands:
+              - mc mb --ignore-existing provisioning/artifacts
+              - mc anonymous set download provisioning/artifacts
+          persistence:
+            enabled: true
+            storageClass: {{ (index .Values "minio-artifacts").persistence.storageClass | default "" }}
+            size: {{ (index .Values "minio-artifacts").persistence.size | default "10Gi" }}
+          resources:
+            requests:
+              cpu: {{ (index .Values "minio-artifacts").resources.requests.cpu | default "100m" }}
+              memory: {{ (index .Values "minio-artifacts").resources.requests.memory | default "256Mi" }}
+            limits:
+              cpu: {{ (index .Values "minio-artifacts").resources.limits.cpu | default "500m" }}
+              memory: {{ (index .Values "minio-artifacts").resources.limits.memory | default "512Mi" }}
+          podSecurityContext:
+            enabled: true
+            fsGroup: 1001
+            fsGroupChangePolicy: "OnRootMismatch"
+          containerSecurityContext:
+            enabled: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            runAsNonRoot: true
+            privileged: false
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          {{- if .Values.global.nodePool }}
+          nodeSelector:
+            node-pool: {{ .Values.global.nodePool }}
+          tolerations:
+            - key: "node-pool"
+              operator: "Equal"
+              value: {{ .Values.global.nodePool | quote }}
+              effect: "NoSchedule"
+          {{- end }}
+
+    # Source 2: HTTPRoute exposing the bucket at artifacts.<domain>
+    - repoURL: {{ .Values.argocd.repoURL }}
+      path: infrastructure/httproutes/minio-artifacts
+      targetRevision: {{ .Values.argocd.targetRevision | default "main" }}
+      helm:
+        releaseName: minio-artifacts-httproute
+        valuesObject:
+          hostname: {{ (index .Values "minio-artifacts").gateway.hostname | default (printf "artifacts.%s" .Values.global.domain) }}
+          namespace: {{ .Values.global.namespace }}
+          minioDomain: {{ .Values.global.domain }}
+          gateway:
+            name: {{ .Values.global.gateway.name }}
+            namespace: {{ .Values.global.gateway.namespace }}
+            sectionName: {{ (index .Values "minio-artifacts").gateway.sectionName | default "https-lfh" }}
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.global.namespace }}
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+      - RespectIgnoreDifferences=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        maxDuration: 5m
+        factor: 2
+{{- end }}
+{{- end }}

--- a/charts/database-secrets/templates/minio-artifacts-externalsecret.yaml
+++ b/charts/database-secrets/templates/minio-artifacts-externalsecret.yaml
@@ -1,0 +1,38 @@
+# Artifacts MinIO ExternalSecret
+# Syncs the dedicated minio-artifacts MinIO root credentials from GCP Secret
+# Manager. Separate from the per-client `minio` secret because the artifacts
+# store is a distinct (public-read) instance. CI's release publisher uses these
+# same credentials to PUT artifacts.
+# Requires GCP keys: {prefix}-minio-artifacts-root-user / -password
+{{- if .Values.minioArtifacts }}
+{{- if .Values.minioArtifacts.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: minio-artifacts-credentials
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: minio-artifacts-credentials
+    app.kubernetes.io/component: external-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secretstore
+    kind: ClusterSecretStore
+  target:
+    name: minio-artifacts
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        root-user: {{ `"{{ .minioRootUser }}"` }}
+        root-password: {{ `"{{ .minioRootPassword }}"` }}
+  data:
+    - secretKey: minioRootUser
+      remoteRef:
+        key: {{ .Values.global.secretPrefix | default .Values.global.namespace }}-minio-artifacts-root-user
+    - secretKey: minioRootPassword
+      remoteRef:
+        key: {{ .Values.global.secretPrefix | default .Values.global.namespace }}-minio-artifacts-root-password
+{{- end }}
+{{- end }}

--- a/charts/database-secrets/templates/minio-artifacts-externalsecret.yaml
+++ b/charts/database-secrets/templates/minio-artifacts-externalsecret.yaml
@@ -1,9 +1,12 @@
-# Artifacts MinIO ExternalSecret
-# Syncs the dedicated minio-artifacts MinIO root credentials from GCP Secret
-# Manager. Separate from the per-client `minio` secret because the artifacts
-# store is a distinct (public-read) instance. CI's release publisher uses these
-# same credentials to PUT artifacts.
+# Artifacts MinIO ExternalSecrets
+# Syncs the dedicated minio-artifacts MinIO credentials from GCP Secret Manager.
+# Separate from the per-client `minio` secret because the artifacts store is a
+# distinct (public-read) instance.
+#   1. minio-artifacts     — ROOT creds; boot the MinIO instance.
+#   2. minio-artifacts-ci  — least-privilege PUBLISHER user; CI uses THIS
+#      (PutObject/GetObject on the artifacts bucket only), never root.
 # Requires GCP keys: {prefix}-minio-artifacts-root-user / -password
+#                    {prefix}-minio-artifacts-ci-password
 {{- if .Values.minioArtifacts }}
 {{- if .Values.minioArtifacts.enabled }}
 apiVersion: external-secrets.io/v1beta1
@@ -34,5 +37,40 @@ spec:
     - secretKey: minioRootPassword
       remoteRef:
         key: {{ .Values.global.secretPrefix | default .Values.global.namespace }}-minio-artifacts-root-password
+---
+# Scoped CI publisher user. Consumed by the minio-artifacts provisioning job
+# (provisioning.usersExistingSecrets) to create the `artifacts-ci` user bound to
+# the minio-artifacts-publisher policy. CI authenticates with these creds.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: minio-artifacts-ci
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: minio-artifacts-ci
+    app.kubernetes.io/component: external-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secretstore
+    kind: ClusterSecretStore
+  target:
+    name: minio-artifacts-ci
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Format required by Bitnami minio provisioning.usersExistingSecrets
+        # (key name is arbitrary; the value is the user definition).
+        ci-publisher: |
+          username=artifacts-ci
+          password={{ `{{ .ciPassword }}` }}
+          disabled=false
+          policies=minio-artifacts-publisher
+          setPolicies=true
+  data:
+    - secretKey: ciPassword
+      remoteRef:
+        key: {{ .Values.global.secretPrefix | default .Values.global.namespace }}-minio-artifacts-ci-password
 {{- end }}
 {{- end }}

--- a/infrastructure/httproutes/minio-artifacts/Chart.yaml
+++ b/infrastructure/httproutes/minio-artifacts/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: minio-artifacts-httproute
+description: HTTPRoute exposing the public-read artifacts MinIO bucket
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/infrastructure/httproutes/minio-artifacts/templates/httproute.yaml
+++ b/infrastructure/httproutes/minio-artifacts/templates/httproute.yaml
@@ -1,0 +1,26 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: minio-artifacts
+  namespace: {{ .Values.namespace }}
+spec:
+  parentRefs:
+    - name: {{ .Values.gateway.name }}
+      namespace: {{ .Values.gateway.namespace }}
+      sectionName: {{ .Values.gateway.sectionName }}
+  hostnames:
+    - {{ .Values.hostname }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      # No path rewrite: MinIO runs with MINIO_DOMAIN={{ .Values.minioDomain }} so a
+      # host-style request to {{ .Values.hostname }} resolves to bucket `artifacts`
+      # with the path as the object key — public URLs stay clean
+      # (/maestroapp/...) AND authenticated S3 writes keep a stable signed path
+      # (a gateway rewrite would break SigV4). CI writes path-style to the same host.
+      backendRefs:
+        - name: minio-artifacts
+          port: 9000
+          weight: 1

--- a/infrastructure/httproutes/minio-artifacts/values.yaml
+++ b/infrastructure/httproutes/minio-artifacts/values.yaml
@@ -1,0 +1,10 @@
+hostname: artifacts.example.com
+namespace: default
+# Parent domain MinIO is configured with (MINIO_DOMAIN). A host-style request to
+# <bucket>.<minioDomain> resolves to that bucket, so artifacts.<minioDomain>
+# serves the `artifacts` bucket with clean object-key paths (no /bucket prefix).
+minioDomain: example.com
+gateway:
+  name: nginx-shared-gateway
+  namespace: nginx-gateway-system
+  sectionName: https-lfh

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1124,6 +1124,31 @@ minio:
     rateLimit:
       enabled: false
 
+# ===== ARTIFACTS STORE: public-read MinIO for desktop releases =====
+# Dedicated MinIO serving Tauri auto-updater manifests + installers at
+# artifacts.localfirsthealth.com. Replaces the legacy downloads.mycure.md box.
+minio-artifacts:
+  enabled: true
+
+  image:
+    repository: bitnamilegacy/minio
+    tag: "2025.7.23-debian-12-r3"
+
+  persistence:
+    size: 10Gi
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  gateway:
+    hostname: ""  # defaults to artifacts.localfirsthealth.com
+    sectionName: https-lfh
+
 # ===== EMAIL TESTING: Mailpit =====
 mailpit:
   enabled: false


### PR DESCRIPTION
## Context
Replaces the legacy **downloads.mycure.md** box (2019 Ubuntu droplet, `178.128.113.192`, nginx static, 83% full, actively probed by scanners) as the host for Tauri desktop-app release artifacts + auto-updater manifests. Live use-case (8-day logs): the Tauri auto-updater — maestroapp leads (53 IPs, all 200).

## What this PR does
Dedicated **`minio-artifacts`** MinIO serving a **public-read** bucket `artifacts` at **artifacts.localfirsthealth.com**.

- **`argocd/applications/templates/minio-artifacts.yaml`** — Bitnami MinIO app (`fullnameOverride: minio-artifacts`), `MINIO_DOMAIN=localfirsthealth.com`, bucket `artifacts` set anonymous-download via provisioning. Sync wave 2.
- **`infrastructure/httproutes/minio-artifacts/`** — HTTPRoute on `nginx-shared-gateway` / `https-lfh` (`*.localfirsthealth.com` wildcard, cert `nginx-gateway-tls-prod` — no cert-manager change).
- **`charts/database-secrets/`** — two ExternalSecrets: `minio-artifacts` (root, boots MinIO) and `minio-artifacts-ci` (scoped publisher user).
- **`values/deployments/mycure-production.yaml`** — `minio-artifacts` enabled (prod only).

### Naming
`minio-artifacts-*` (purpose-based, groups under the existing `minio` app). Bucket stays `artifacts`; public host stays `artifacts.localfirsthealth.com`.

### URL scheme (no path rewrite)
`MINIO_DOMAIN=localfirsthealth.com` → host-style `artifacts.localfirsthealth.com/<key>` resolves bucket `artifacts` (clean public URLs). CI publishes path-style to the same host. No gateway path-rewrite (would break S3 SigV4 on writes).

### Least-privilege CI (no root in CI)
CI publishes with a scoped **`artifacts-ci`** user (`minio-artifacts-publisher` policy: `PutObject`/`GetObject`/`ListBucket` on `artifacts` only), not root. Password sourced from a GCP key via `provisioning.usersExistingSecrets` — never plaintext in git.

### Why dedicated (not the existing `minio`)
Public-read store isolated from private `monobase-files` (which is `enabled: false`/GCS in prod anyway) — defense-in-depth per public/private best practice.

## Prerequisites (done)
GCP (`mc-v4-prod`): `mycure-production-minio-artifacts-root-user`, `-root-password`, `-ci-password`. GitHub Actions: `ARTIFACTS_S3_ACCESS_KEY_ID` (=`artifacts-ci`) / `ARTIFACTS_S3_SECRET_ACCESS_KEY`.

## Validation
`helm template` renders cleanly (app, HTTPRoute, both ExternalSecrets, scoped policy + user); demo/preprod skip the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
