### PR TITLE
fix(minio-artifacts): pin provisioning os-shell init image to bitnamilegacy

### DIFF
--- a/argocd/applications/templates/minio-artifacts.yaml
+++ b/argocd/applications/templates/minio-artifacts.yaml
@@ -44,6 +44,13 @@ spec:
           image:
             repository: {{ (index .Values "minio-artifacts").image.repository | default "bitnamilegacy/minio" }}
             tag: {{ (index .Values "minio-artifacts").image.tag | default "2025.7.23-debian-12-r3" }}
+          # The provisioning Job's os-shell init container defaults to
+          # docker.io/bitnami/os-shell, which 404s since Bitnami moved images to
+          # bitnamilegacy/ (Aug 2025). Point it at the legacy mirror too.
+          defaultInitContainers:
+            volumePermissions:
+              image:
+                repository: bitnamilegacy/os-shell
           mode: standalone
           statefulset:
             replicaCount: 1


### PR DESCRIPTION
The minio-artifacts provisioning Job was stuck in `Init:ImagePullBackOff` — its os-shell init container defaulted to `docker.io/bitnami/os-shell:12-debian-12-r35`, which 404s since Bitnami moved images to `bitnamilegacy/` (Aug 2025). So the bucket's anonymous-download policy + the scoped `artifacts-ci` user were never created.

Fix: override `defaultInitContainers.volumePermissions.image.repository` (the chart's only os-shell reference, per _helpers.tpl `minio.volumePermissions.image`) to `bitnamilegacy/os-shell`.

Follow-up to #67. helm template validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)