### PR TITLE
fix(minio-artifacts): correct os-shell param to volumePermissions.image (chart 14.10.5)

### DIFF
--- a/argocd/applications/templates/minio-artifacts.yaml
+++ b/argocd/applications/templates/minio-artifacts.yaml
@@ -46,7 +46,13 @@ spec:
             tag: {{ (index .Values "minio-artifacts").image.tag | default "2025.7.23-debian-12-r3" }}
           # The provisioning Job's os-shell init container defaults to
           # docker.io/bitnami/os-shell, which 404s since Bitnami moved images to
-          # bitnamilegacy/ (Aug 2025). Point it at the legacy mirror too.
+          # bitnamilegacy/ (Aug 2025). Point it at the legacy mirror.
+          # Chart 14.10.5 reads `volumePermissions.image`; newer 14.x renamed it to
+          # `defaultInitContainers.volumePermissions.image`. Set both so a chart
+          # bump within the `14.x.x` range can't reintroduce the broken image.
+          volumePermissions:
+            image:
+              repository: bitnamilegacy/os-shell
           defaultInitContainers:
             volumePermissions:
               image:


### PR DESCRIPTION
Follow-up to #68. The os-shell override used the newer chart's path (`defaultInitContainers.volumePermissions.image`); chart **14.10.5** reads top-level **`volumePermissions.image`** for the provisioning Job's `wait-for-available-minio` init container. Verified against `helm template bitnamicharts/minio:14.10.5`. The provisioning job was still ImagePullBackOff, so the bucket anon policy + scoped `artifacts-ci` user never provisioned. Sets both paths for 14.x robustness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)