### PR TITLE
ops(preprod): pause cadence — mirror of prod's 06-27 holding measure

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -972,7 +972,16 @@ mailpit:
 
 # ===== P2P SYNC: Cadence =====
 cadence:
-  enabled: true  # re-enabled 2026-04-29 to match staging (incident root cause fixed in 0.5.x line)
+  # PAUSED 2026-06-29 — mirror of prod's 06-27 holding measure (PR ~mid-June).
+  # Preprod PG hit 100% disk today; cadence_y2026m06d26 alone was 125 GB
+  # of re-logged billing-items/queue-items/analytics rows (same watcher
+  # re-log loop / hapihub-next background-job churn that forced the prod
+  # pause). Dropped d26 manually 09:30 UTC to reclaim 124 GB (100% → 38%);
+  # this pause prevents the next d27/d28/d29 from refilling. Re-enable
+  # AFTER the watcher/churn fix lands — until then preprod has no offline
+  # sync, but the API + login + web app read PG directly and are UNAFFECTED.
+  # See monobase-infra#63.
+  enabled: false # was: true
 
   image:
     repository: ghcr.io/mycurelabs/cadence


### PR DESCRIPTION
Preprod PG primary hit 100 % disk (200/200 GB, 256 MB free) this morning. `cadence.changelog_y2026m06d26` alone was 125 GB — same watcher re-log loop / hapihub-next background-job churn that forced the prod pause on 06-27. Reclaimed 124 GB by manually dropping d26 (disk now 38 %). This pause prevents d27/d28/d29 from refilling.

Fleet effect identical to prod since 06-27: API / login / web / hapihub-next read PG directly and are UNAFFECTED; only offline embedded clients lose realtime sync (they reconcile on cadence re-enable). Re-enable AFTER the watcher/churn fix lands. Tracking in infra#63 + active root-cause investigation of pg_poll.rs applier-echo suppression.