### PR TITLE
feat(nocodb): self-host NocoDB on preprod for business to browse Postgres

### DIFF
--- a/argocd/applications/templates/nocodb.yaml
+++ b/argocd/applications/templates/nocodb.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.nocodb.enabled }}
+# ArgoCD Application: NocoDB (self-hosted no-code DB UI for business)
+# Sync Wave 3 - Deploy application after database
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.global.namespace }}-nocodb
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    path: charts/nocodb
+    repoURL: {{ .Values.argocd.repoURL }}
+    targetRevision: {{ .Values.argocd.targetRevision | default "main" }}
+    helm:
+      releaseName: nocodb
+      valuesObject:
+        {{- toYaml .Values.nocodb | nindent 8 }}
+        global: {{ .Values.global | toYaml | nindent 10 }}
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.global.namespace }}
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        maxDuration: 5m
+{{- end }}

--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: nocodb
+description: Self-hosted NocoDB (no-code DB UI) for business to browse Postgres data
+type: application
+version: 0.1.0
+appVersion: "2026.06.2"

--- a/charts/nocodb/templates/_helpers.tpl
+++ b/charts/nocodb/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nocodb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name.
+*/}}
+{{- define "nocodb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "nocodb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "nocodb.labels" -}}
+helm.sh/chart: {{ include "nocodb.chart" . }}
+{{ include "nocodb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: mycureapp
+{{- end }}
+
+{{- define "nocodb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nocodb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "nocodb.namespace" -}}
+{{- default .Release.Namespace .Values.global.namespace }}
+{{- end }}
+
+{{/*
+Gateway hostname - defaults to nocodb.{global.domain}
+*/}}
+{{- define "nocodb.gateway.hostname" -}}
+{{- if .Values.gateway.hostname }}
+{{- .Values.gateway.hostname }}
+{{- else }}
+{{- printf "nocodb.%s" .Values.global.domain }}
+{{- end }}
+{{- end }}
+
+{{- define "nocodb.gateway.name" -}}
+{{- default "shared-gateway" .Values.global.gateway.name }}
+{{- end }}
+
+{{- define "nocodb.gateway.namespace" -}}
+{{- default "gateway-system" .Values.global.gateway.namespace }}
+{{- end }}
+
+{{/*
+Node pool - component-level override, else global. Empty if unset.
+*/}}
+{{- define "nocodb.nodePool" -}}
+{{- if hasKey .Values "nodePool" -}}
+  {{- if and .Values.nodePool (hasKey .Values.nodePool "enabled") (not .Values.nodePool.enabled) -}}
+  {{- else if and .Values.nodePool .Values.nodePool.name -}}
+    {{- .Values.nodePool.name -}}
+  {{- else if and .Values.global .Values.global.nodePool -}}
+    {{- .Values.global.nodePool -}}
+  {{- end -}}
+{{- else if and .Values.global .Values.global.nodePool -}}
+  {{- .Values.global.nodePool -}}
+{{- end -}}
+{{- end -}}

--- a/charts/nocodb/templates/deployment.yaml
+++ b/charts/nocodb/templates/deployment.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nocodb.fullname" . }}
+  namespace: {{ include "nocodb.namespace" . }}
+  labels:
+    {{- include "nocodb.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  # RWO PVC can't attach to old+new pods at once; rolling update would deadlock.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "nocodb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nocodb.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.targetPort }}
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.probePath }}
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.probePath }}
+            port: http
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.config }}
+        env:
+        {{- range $key, $value := .Values.config }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        volumeMounts:
+        - name: data
+          mountPath: /usr/app/data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ include "nocodb.fullname" . }}-data
+      {{- $nodePool := include "nocodb.nodePool" . -}}
+      {{- if or $nodePool .Values.nodeSelector }}
+      nodeSelector:
+        {{- if $nodePool }}
+        node-pool: {{ $nodePool }}
+        {{- end }}
+        {{- with .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or $nodePool .Values.tolerations }}
+      tolerations:
+        {{- if $nodePool }}
+        - key: "node-pool"
+          operator: "Equal"
+          value: {{ $nodePool | quote }}
+          effect: "NoSchedule"
+        {{- end }}
+        {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/charts/nocodb/templates/httproute.yaml
+++ b/charts/nocodb/templates/httproute.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.enabled .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "nocodb.fullname" . }}
+  namespace: {{ include "nocodb.namespace" . }}
+  labels:
+    {{- include "nocodb.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "nocodb.gateway.name" . }}
+      namespace: {{ include "nocodb.gateway.namespace" . }}
+      {{- if .Values.gateway.sectionName }}
+      sectionName: {{ .Values.gateway.sectionName }}
+      {{- else }}
+      sectionName: https
+      {{- end }}
+  hostnames:
+    - {{ include "nocodb.gateway.hostname" . }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "nocodb.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 1
+{{- end }}

--- a/charts/nocodb/templates/pvc.yaml
+++ b/charts/nocodb/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "nocodb.fullname" . }}-data
+  namespace: {{ include "nocodb.namespace" . }}
+  labels:
+    {{- include "nocodb.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/nocodb/templates/service.yaml
+++ b/charts/nocodb/templates/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nocodb.fullname" . }}
+  namespace: {{ include "nocodb.namespace" . }}
+  labels:
+    {{- include "nocodb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "nocodb.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/nocodb/values.yaml
+++ b/charts/nocodb/values.yaml
@@ -1,0 +1,49 @@
+global:
+  domain: example.com
+  namespace: example
+  gateway:
+    name: shared-gateway
+    namespace: gateway-system
+
+enabled: true
+replicaCount: 1
+
+image:
+  repository: nocodb/nocodb
+  tag: "2026.06.2"
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+# SQLite metadata + attachments live here; PVC keeps them across pod restarts.
+persistence:
+  size: 5Gi
+  storageClass: ""  # "" = DO default (do-block-storage)
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 1536Mi
+
+gateway:
+  enabled: true
+  hostname: ""        # defaults to nocodb.{global.domain}
+  sectionName: ""     # e.g. https-preprod-lfh
+
+# Plain (non-secret) env. NC_DB / NC_AUTH_JWT_SECRET / NC_ADMIN_* are intentionally
+# absent for preprod: SQLite metadata default, first signup becomes super-admin,
+# auto-generated JWT is fine for an ephemeral env.
+config:
+  NC_DISABLE_PG_DATA_REFLECTION: "true"
+
+probePath: /api/health
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/values/deployments/mycure-demo.yaml
+++ b/values/deployments/mycure-demo.yaml
@@ -136,6 +136,11 @@ mycure-dashboard:
   podDisruptionBudget:
     enabled: false
 
+# ===== INTERNAL TOOL: NocoDB (no-code DB UI for business, issue #2041) =====
+# Disabled in demo; enabled on preprod only for now.
+nocodb:
+  enabled: false
+
 # ===== HEALTHCARE: Frontend Application (mycureapp) =====
 mycure:
   enabled: true

--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -137,6 +137,42 @@ mycure-dashboard:
   podDisruptionBudget:
     enabled: false
 
+# ===== INTERNAL TOOL: NocoDB (no-code DB UI for business, issue #2041) =====
+# Self-hosted, single replica, SQLite metadata on a PVC. Business connects the
+# hapihub Postgres as a READ-ONLY data source via the UI (NC_DISABLE_PG_DATA_
+# REFLECTION=true stops NocoDB creating schemas in the connected DB). No NC_DB /
+# NC_ADMIN_* / JWT secret here: first signup becomes super-admin and an
+# auto-generated JWT is fine for this ephemeral env. Prod adds those via an
+# ExternalSecret.
+nocodb:
+  enabled: true
+
+  image:
+    repository: nocodb/nocodb
+    tag: "2026.06.2"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1536Mi
+
+  persistence:
+    size: 5Gi
+
+  gateway:
+    hostname: ""  # defaults to nocodb.preprod.localfirsthealth.com
+    sectionName: https-preprod-lfh
+
+  config:
+    NC_PUBLIC_URL: "https://nocodb.preprod.localfirsthealth.com"
+    NC_DISABLE_PG_DATA_REFLECTION: "true"
+
 # ===== HEALTHCARE: MyCure PXP (patient-facing web app) =====
 mycure-pxp:
   enabled: true

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -131,6 +131,13 @@ mycure-dashboard:
   podDisruptionBudget:
     enabled: false
 
+# ===== INTERNAL TOOL: NocoDB (no-code DB UI for business, issue #2041) =====
+# Disabled until validated on preprod. Production rollout (separate PR) flips this
+# on and adds an ExternalSecret for a stable NC_AUTH_JWT_SECRET + admin bootstrap,
+# plus a dedicated read-only Postgres role for the data source.
+nocodb:
+  enabled: false
+
 # ===== HEALTHCARE: MyCure PXP (patient-facing web app) =====
 mycure-pxp:
   enabled: true


### PR DESCRIPTION
## What

Self-hosts **NocoDB** (no-code DB UI) so the business team can browse the hapihub Postgres without SQL. **Preprod only** for now — production is a follow-up after this is validated.

Implements mycurelabs/monobase-mycure#2041 ("Integrate NocoDB to PG for biz to use. Self host for now.").

## How

- **`charts/nocodb/`** — minimal Helm chart (Deployment + Service + HTTPRoute + PVC), modelled on `mycure-dashboard`.
  - Single replica, `strategy: Recreate` (a RWO PVC can't attach to old+new pods during a rolling update).
  - Image pinned `nocodb/nocodb:2026.06.2`, port 8080, `/api/health` probes.
  - **SQLite metadata + attachments on a 5Gi PVC** at `/usr/app/data` — survives pod restarts. The actual business data always lives in Postgres and is never copied into NocoDB.
  - Lands on the **staging pool** via the shared `nodePool` helper (nodeSelector + toleration).
- **`argocd/applications/templates/nocodb.yaml`** — ArgoCD Application gated on `.Values.nocodb.enabled`.
- **values** — enabled on `mycure-preprod` (`nocodb.preprod.localfirsthealth.com`), disabled stubs on `production` + `demo`.

## Data-source safety

Business connects the hapihub PG as a **read-only data source via the UI** at runtime. `NC_DISABLE_PG_DATA_REFLECTION=true` stops NocoDB from creating schemas in the connected DB. No `NC_DB` / `NC_ADMIN_*` / JWT secret on preprod: SQLite metadata default, first signup becomes super-admin, and an auto-generated JWT is fine for this ephemeral env.

## Resource impact

**No cluster expansion.** ~512Mi request fits the staging pool's existing headroom (~900Mi–1.1Gi free/node). CPU request 100m (limit 1000m).

## Verify after merge (ArgoCD syncs preprod)

1. `kubectl -n mycure-preprod get pod -l app.kubernetes.io/name=nocodb -o wide` → Running on a `staging-*` node, PVC Bound.
2. Open `https://nocodb.preprod.localfirsthealth.com` → sign up (first user = super-admin).
3. `kubectl delete pod` → re-open URL, still logged in = PVC persistence works.
4. New Base → connect Postgres `postgresql:5432` db `hapihub` (pw from `postgresql` secret), **schema + data editing disabled** → browse a table, confirm read-only, confirm no new schema appeared in `hapihub`.

## Production follow-up (separate PR)

Flip `nocodb.enabled` on in `mycure-production.yaml` (host `nocodb.localfirsthealth.com`, `sectionName: https-lfh`), add an ExternalSecret for a stable `NC_AUTH_JWT_SECRET` + admin bootstrap, and create a dedicated read-only Postgres role for the data source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
