### PR TITLE
fix(nocodb): run non-root for restricted PodSecurity + correct health path

### DIFF
--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nocodb
 description: Self-hosted NocoDB (no-code DB UI) for business to browse Postgres data
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "2026.06.2"

--- a/charts/nocodb/templates/deployment.yaml
+++ b/charts/nocodb/templates/deployment.yaml
@@ -19,8 +19,16 @@ spec:
       labels:
         {{- include "nocodb.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
@@ -41,12 +49,13 @@ spec:
           periodSeconds: 10
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
-        {{- if .Values.config }}
         env:
+        # Non-root uid can't write the image default HOME (/root); point it at the PVC.
+        - name: HOME
+          value: /usr/app/data
         {{- range $key, $value := .Values.config }}
         - name: {{ $key }}
           value: {{ $value | quote }}
-        {{- end }}
         {{- end }}
         volumeMounts:
         - name: data

--- a/charts/nocodb/values.yaml
+++ b/charts/nocodb/values.yaml
@@ -36,13 +36,32 @@ gateway:
   hostname: ""        # defaults to nocodb.{global.domain}
   sectionName: ""     # e.g. https-preprod-lfh
 
+# Namespace enforces the restricted PodSecurity standard, so NocoDB must run
+# non-root. fsGroup makes the PVC group-writable for the runAsUser; HOME is
+# pointed at the PVC (env below) because the image's default /root isn't writable
+# for a non-root uid. Verified: nocodb 2026.06.2 boots clean as uid 1000.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  # readOnlyRootFilesystem intentionally NOT set: NocoDB writes to its cwd/tmp.
+
 # Plain (non-secret) env. NC_DB / NC_AUTH_JWT_SECRET / NC_ADMIN_* are intentionally
 # absent for preprod: SQLite metadata default, first signup becomes super-admin,
 # auto-generated JWT is fine for an ephemeral env.
 config:
   NC_DISABLE_PG_DATA_REFLECTION: "true"
 
-probePath: /api/health
+probePath: /api/v1/health
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Follow-up to #73. Preprod pods were rejected by the namespace's `restricted` PodSecurity standard (no securityContext). Adds non-root securityContext (uid 1000 + fsGroup so the PVC stays writable), points HOME at the PVC, and fixes the probe path to `/api/v1/health` (correct for nocodb 2026.06.2).

Verified locally: the image boots clean as uid 1000 with an fsGroup-owned volume ("Nest application successfully started"), `/api/v1/health` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)