### PR TITLE
fix(nocodb): allow connecting the in-cluster Postgres data source

### DIFF
--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nocodb
 description: Self-hosted NocoDB (no-code DB UI) for business to browse Postgres data
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "2026.06.2"

--- a/charts/nocodb/values.yaml
+++ b/charts/nocodb/values.yaml
@@ -60,6 +60,11 @@ securityContext:
 # auto-generated JWT is fine for an ephemeral env.
 config:
   NC_DISABLE_PG_DATA_REFLECTION: "true"
+  # Allow connecting an external data source on a private/cluster address
+  # (the hapihub Postgres is an in-cluster ClusterIP, host "postgresql").
+  # Without this, NocoDB's SSRF guard rejects it: "Connection to internal
+  # hosts is not allowed".
+  NC_ALLOW_LOCAL_EXTERNAL_DBS: "true"
 
 probePath: /api/v1/health
 


### PR DESCRIPTION
Follow-up to #73/#74. NocoDB's SSRF guard blocks external data sources on private addresses, so connecting the hapihub Postgres (ClusterIP `postgresql`) failed with "Connection to internal hosts is not allowed". Sets `NC_ALLOW_LOCAL_EXTERNAL_DBS=true` (chart default — prod needs it too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)