### PR TITLE
feat(nocodb): chart-managed bootstrap Job to pre-add the read-only data source

### DIFF
--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nocodb
 description: Self-hosted NocoDB (no-code DB UI) for business to browse Postgres data
 type: application
-version: 0.1.2
+version: 0.2.0
 appVersion: "2026.06.2"

--- a/charts/nocodb/files/bootstrap.js
+++ b/charts/nocodb/files/bootstrap.js
@@ -1,0 +1,117 @@
+// NocoDB data-source bootstrap. Idempotent. Runs in the nocodb image (has node,
+// global fetch, and the `pg` driver via NODE_PATH=/usr/src/app/node_modules).
+//
+// 1. ensure a read-only Postgres role exists on the target DB
+// 2. ensure the NocoDB super-admin exists (signin, else first-signup)
+// 3. ensure a base + an external read-only pg source pointing at that DB exist
+//
+// All identifiers (role, schema, db) come from chart values, not user input.
+const { Client } = require('pg');
+
+const E = process.env;
+const NC_URL = E.NC_URL;
+const ADMIN_EMAIL = E.ADMIN_EMAIL;
+const ADMIN_PASSWORD = E.ADMIN_PASSWORD;
+const BASE_TITLE = E.BASE_TITLE;
+const SOURCE_ALIAS = E.SOURCE_ALIAS;
+const SEARCH_PATH = (E.SEARCH_PATH || 'public').split(',').map(s => s.trim()).filter(Boolean);
+const PG = {
+  host: E.PG_HOST, port: +(E.PG_PORT || 5432), database: E.PG_DB,
+  adminUser: E.PG_ADMIN_USER || 'postgres', adminPassword: E.PG_ADMIN_PASSWORD,
+  roUser: E.RO_USER || 'nocodb_ro', roPassword: E.RO_PASSWORD,
+};
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const sq = s => s.replace(/'/g, "''"); // single-quote escape for SQL literals
+
+async function ensureRole() {
+  const c = new Client({
+    host: PG.host, port: PG.port, database: PG.database,
+    user: PG.adminUser, password: PG.adminPassword,
+  });
+  await c.connect();
+  try {
+    const { rows } = await c.query('select 1 from pg_roles where rolname=$1', [PG.roUser]);
+    const verb = rows.length ? 'ALTER' : 'CREATE';
+    await c.query(`${verb} ROLE ${PG.roUser} LOGIN PASSWORD '${sq(PG.roPassword)}'`);
+    await c.query(`GRANT CONNECT ON DATABASE ${PG.database} TO ${PG.roUser}`);
+    for (const s of SEARCH_PATH) {
+      await c.query(`GRANT USAGE ON SCHEMA ${s} TO ${PG.roUser}`);
+      await c.query(`GRANT SELECT ON ALL TABLES IN SCHEMA ${s} TO ${PG.roUser}`);
+      await c.query(`ALTER DEFAULT PRIVILEGES IN SCHEMA ${s} GRANT SELECT ON TABLES TO ${PG.roUser}`);
+    }
+    console.log(`[role] ${verb} ${PG.roUser} ok`);
+  } finally {
+    await c.end();
+  }
+}
+
+async function api(path, opts = {}, token) {
+  const r = await fetch(NC_URL + path, {
+    ...opts,
+    headers: { 'Content-Type': 'application/json', ...(token ? { 'xc-auth': token } : {}), ...(opts.headers || {}) },
+  });
+  const text = await r.text();
+  let body; try { body = JSON.parse(text); } catch { body = text; }
+  return { status: r.status, body };
+}
+
+async function waitHealth() {
+  for (let i = 0; i < 60; i++) {
+    try { const r = await fetch(NC_URL + '/api/v1/health'); if (r.ok) { console.log('[health] ok'); return; } } catch {}
+    await sleep(5000);
+  }
+  throw new Error('nocodb health timeout');
+}
+
+async function auth() {
+  let r = await api('/api/v1/auth/user/signin', { method: 'POST', body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }) });
+  if (r.body && r.body.token) { console.log('[auth] signed in'); return r.body.token; }
+  r = await api('/api/v1/auth/user/signup', { method: 'POST', body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }) });
+  if (r.body && r.body.token) { console.log('[auth] signed up (first user)'); return r.body.token; }
+  throw new Error('auth failed: ' + JSON.stringify(r.body));
+}
+
+async function main() {
+  await ensureRole();
+  await waitHealth();
+  const token = await auth();
+
+  const me = await api('/api/v1/auth/user/me', {}, token);
+  const roles = (me.body && me.body.roles) || {};
+  if (!(roles['org-level-creator'] || roles['super'])) {
+    throw new Error('admin lacks creator role (' + JSON.stringify(roles) + '); the configured admin must be the FIRST signup — reset NocoDB metadata if another user was created first');
+  }
+
+  const list = await api('/api/v2/meta/bases', {}, token);
+  let base = ((list.body && list.body.list) || []).find(b => b.title === BASE_TITLE);
+  if (!base) {
+    const c = await api('/api/v2/meta/bases', { method: 'POST', body: JSON.stringify({ title: BASE_TITLE }) }, token);
+    if (!c.body || !c.body.id) throw new Error('base create failed: ' + JSON.stringify(c.body));
+    base = c.body;
+    console.log('[base] created', base.id);
+  } else {
+    console.log('[base] exists', base.id);
+  }
+
+  const srcs = await api(`/api/v2/meta/bases/${base.id}/sources`, {}, token);
+  const arr = Array.isArray(srcs.body) ? srcs.body : ((srcs.body && srcs.body.list) || []);
+  if (arr.some(s => s.alias === SOURCE_ALIAS)) {
+    console.log('[source] already present, nothing to do');
+    return;
+  }
+  const create = await api(`/api/v2/meta/bases/${base.id}/sources`, {
+    method: 'POST',
+    body: JSON.stringify({
+      alias: SOURCE_ALIAS, type: 'pg', is_schema_readonly: true, is_data_readonly: true,
+      config: { client: 'pg', connection: { host: PG.host, port: PG.port, user: PG.roUser, password: PG.roPassword, database: PG.database }, searchPath: SEARCH_PATH },
+    }),
+  }, token);
+  if (create.status >= 400 || !create.body || create.body.error || create.body.msg) {
+    throw new Error('source create failed: ' + JSON.stringify(create.body));
+  }
+  console.log('[source] created', create.body.id, '(tables import asynchronously)');
+}
+
+main().then(() => { console.log('bootstrap done'); process.exit(0); })
+  .catch(e => { console.error('bootstrap failed:', e.message); process.exit(1); });

--- a/charts/nocodb/templates/bootstrap-configmap.yaml
+++ b/charts/nocodb/templates/bootstrap-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.enabled .Values.bootstrap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nocodb.fullname" . }}-bootstrap-script
+  namespace: {{ include "nocodb.namespace" . }}
+  labels:
+    {{- include "nocodb.labels" . | nindent 4 }}
+data:
+  bootstrap.js: |
+{{ .Files.Get "files/bootstrap.js" | indent 4 }}
+{{- end }}

--- a/charts/nocodb/templates/bootstrap-job.yaml
+++ b/charts/nocodb/templates/bootstrap-job.yaml
@@ -1,0 +1,100 @@
+{{- if and .Values.enabled .Values.bootstrap.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "nocodb.fullname" . }}-bootstrap
+  namespace: {{ include "nocodb.namespace" . }}
+  labels:
+    {{- include "nocodb.labels" . | nindent 4 }}
+  annotations:
+    # Run after the Deployment is synced & healthy, on every install/upgrade.
+    # Idempotent, so re-running is safe. Honoured by both Helm and ArgoCD.
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 1800
+  template:
+    metadata:
+      labels:
+        {{- include "nocodb.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: bootstrap
+    spec:
+      restartPolicy: Never
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: bootstrap
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        command: ["node", "/scripts/bootstrap.js"]
+        env:
+        - name: NODE_PATH
+          value: /usr/src/app/node_modules
+        - name: HOME
+          value: /tmp
+        - name: NC_URL
+          value: "http://{{ include "nocodb.fullname" . }}:{{ .Values.service.port }}"
+        - name: BASE_TITLE
+          value: {{ .Values.bootstrap.baseTitle | quote }}
+        - name: SOURCE_ALIAS
+          value: {{ .Values.bootstrap.sourceAlias | quote }}
+        - name: SEARCH_PATH
+          value: {{ .Values.bootstrap.searchPath | quote }}
+        - name: PG_HOST
+          value: {{ .Values.bootstrap.pg.host | quote }}
+        - name: PG_PORT
+          value: {{ .Values.bootstrap.pg.port | quote }}
+        - name: PG_DB
+          value: {{ .Values.bootstrap.pg.database | quote }}
+        - name: PG_ADMIN_USER
+          value: {{ .Values.bootstrap.pg.adminUser | quote }}
+        - name: RO_USER
+          value: {{ .Values.bootstrap.roUser | quote }}
+        - name: PG_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.bootstrap.pg.adminSecret.name }}
+              key: {{ .Values.bootstrap.pg.adminSecret.key }}
+        - name: ADMIN_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "nocodb.fullname" . }}-bootstrap
+              key: admin-email
+        - name: ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "nocodb.fullname" . }}-bootstrap
+              key: admin-password
+        - name: RO_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "nocodb.fullname" . }}-bootstrap
+              key: ro-password
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+      volumes:
+      - name: scripts
+        configMap:
+          name: {{ include "nocodb.fullname" . }}-bootstrap-script
+      {{- $nodePool := include "nocodb.nodePool" . -}}
+      {{- if $nodePool }}
+      nodeSelector:
+        node-pool: {{ $nodePool }}
+      tolerations:
+        - key: "node-pool"
+          operator: "Equal"
+          value: {{ $nodePool | quote }}
+          effect: "NoSchedule"
+      {{- end }}
+{{- end }}

--- a/charts/nocodb/templates/externalsecret.yaml
+++ b/charts/nocodb/templates/externalsecret.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.enabled .Values.bootstrap.enabled }}
+{{- $prefix := .Values.global.secretPrefix | default .Values.global.namespace }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "nocodb.fullname" . }}-bootstrap
+  namespace: {{ include "nocodb.namespace" . }}
+  labels:
+    {{- include "nocodb.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: {{ .Values.bootstrap.externalSecrets.secretStore | default "gcp-secretstore" }}
+    kind: {{ .Values.bootstrap.externalSecrets.secretStoreKind | default "ClusterSecretStore" }}
+  refreshInterval: {{ .Values.bootstrap.externalSecrets.refreshInterval | default "1h" }}
+  target:
+    name: {{ include "nocodb.fullname" . }}-bootstrap
+    creationPolicy: Owner
+  data:
+    - secretKey: admin-email
+      remoteRef:
+        key: {{ $prefix }}-nocodb-admin-email
+    - secretKey: admin-password
+      remoteRef:
+        key: {{ $prefix }}-nocodb-admin-password
+    - secretKey: ro-password
+      remoteRef:
+        key: {{ $prefix }}-nocodb-ro-password
+{{- end }}

--- a/charts/nocodb/values.yaml
+++ b/charts/nocodb/values.yaml
@@ -68,6 +68,31 @@ config:
 
 probePath: /api/v1/health
 
+# Post-install Job that pre-adds the read-only Postgres data source (no
+# declarative source config exists in NocoDB — it lives in NocoDB's metadata).
+# Idempotent. Needs a `<release>-bootstrap` secret (admin-email, admin-password,
+# ro-password) — provided by the ExternalSecret below — plus the existing PG
+# admin secret to create the read-only role.
+bootstrap:
+  enabled: false
+  baseTitle: "MYCURE hapihub (read-only)"
+  sourceAlias: hapihub
+  searchPath: public      # comma-separated for multiple schemas
+  roUser: nocodb_ro
+  pg:
+    host: postgresql
+    port: 5432
+    database: hapihub
+    adminUser: postgres
+    adminSecret:
+      name: postgresql
+      key: postgres-password
+  externalSecrets:
+    secretStore: gcp-secretstore
+    secretStoreKind: ClusterSecretStore
+    refreshInterval: 1h
+    # remote GCP keys: <secretPrefix>-nocodb-{admin-email,admin-password,ro-password}
+
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -173,6 +173,12 @@ nocodb:
     NC_PUBLIC_URL: "https://nocodb.preprod.localfirsthealth.com"
     NC_DISABLE_PG_DATA_REFLECTION: "true"
 
+  # Pre-add the read-only hapihub data source on deploy (idempotent post-install
+  # Job). Admin + RO creds come from GCP via ExternalSecret (keys
+  # mycure-production-nocodb-* — preprod reuses the production secretPrefix).
+  bootstrap:
+    enabled: true
+
 # ===== HEALTHCARE: MyCure PXP (patient-facing web app) =====
 mycure-pxp:
   enabled: true


### PR DESCRIPTION
Makes the hapihub data-source pre-add reproducible in the chart (asked for: 'can it be included in the chart?'). NocoDB has no declarative external-source config, so this is an idempotent post-install Job driving the meta API.

- `files/bootstrap.js` runs in the nocodb image (reuses its node + `pg` + global `fetch`): ensures a read-only PG role → ensures super-admin (signin/first-signup) → ensures base + read-only pg source. Re-runnable.
- post-install/post-upgrade (PostSync) hook Job, non-root, same node pool.
- ExternalSecret pulls admin + RO creds from GCP (`<secretPrefix>-nocodb-*`).
- Enabled on preprod; `NC_ALLOW_LOCAL_EXTERNAL_DBS` already set so it can reach the in-cluster PG.

Verified end-to-end by hand first (role + meta API). GCP keys `mycure-production-nocodb-*` created out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)