### PR TITLE
chore(hapihub): bump preprod + prod 11.20.36 → 11.20.37

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -224,7 +224,7 @@ hapihub:
 
   image:
     repository: ghcr.io/mycurelabs/hapihub
-    tag: "11.20.36"
+    tag: "11.20.37"
     pullPolicy: IfNotPresent
 
   # Daily cleanup of expired Better Auth sessions (they never self-delete).

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -348,7 +348,7 @@ hapihubNext:
 
   image:
     repository: ghcr.io/mycurelabs/hapihub
-    tag: "11.20.36"
+    tag: "11.20.37"
     pullPolicy: IfNotPresent
 
   # Daily cleanup of expired Better Auth sessions (they never self-delete).


### PR DESCRIPTION
Ships mono#2120 (`_create` updatedAt — mono#2103 deploy gate) + mono#2122 (coverage batching + index — mono#2104). Post-deploy proofs: NULL-count growth stops (gate), `\d insurance_coverages` shows new index, pg_stat_statements 1 stmt/list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)