### PR TITLE
fix(hapihub-next): BUN_JSC_forceRAMSize=3GiB (mono#2114 OOM stopgap)

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -414,6 +414,13 @@ hapihubNext:
     STORAGE_DOWNLOAD_URL_HOST: "https://hapihub-next.localfirsthealth.com"
 
   env:
+    # #2114 OOM stopgap: JSC sizes heap-growth heuristics off machine RAM, not
+    # the cgroup — under burst allocation the heap overshoots the container
+    # limit before a full GC runs. Force it to see 3GiB (limit is 4Gi; the
+    # remaining ~1GiB covers non-JSC memory: Buffers, in-pod Chromium/export
+    # workers — RUN_WORKERS=true here).
+    - name: BUN_JSC_forceRAMSize
+      value: "3221225472"
     - name: BETTER_AUTH_RATE_LIMIT_ENABLED
       value: "true"
     - name: BETTER_AUTH_RATE_LIMIT_WINDOW


### PR DESCRIPTION
## Summary

Zero-app-code deployment stopgap from the mono#2114 RCA (hapihub-next OOM crashloop): JSC sizes heap-growth heuristics off **machine RAM**, not the cgroup, so burst allocations overshoot the 4Gi limit before a full GC runs. `BUN_JSC_forceRAMSize=3221225472` (3GiB) makes the collector see the actual budget; the remaining ~1GiB covers non-JSC memory — Buffers plus the in-pod export/PDF Chromium workers (**`RUN_WORKERS=true` on these pods** — verified live; this is also why one pod spikes when a pg-boss export/PDF job lands on it).

App-side fixes ship in the mono stack #2119 → #2121 → #2127 → #2130 (sub-request fan-out batching, `$limit` clamp, export Buffer path, Chromium try/finally + semaphore).

Follow-up worth considering separately: split workers to a dedicated deployment (`RUN_WORKERS=false` on API pods + a worker deployment) so job memory can't evict request-serving pods at all.

## Verification
- YAML validated; `hapihubNext.env` renders the entry alongside the existing BETTER_AUTH vars (chart passes `.Values.env` through verbatim)
- After merge + root-app sync: `kubectl exec deploy/hapihub-next -- env | grep BUN_JSC` and watch restart counts / `rss_mb` in the new request-completed logs (mono #2119)

🤖 Generated with [Claude Code](https://claude.com/claude-code)