### PR TITLE
fix(cadence): preprod → 0.6.1 (DDL advisory lock + symmetric receive gate)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -1014,11 +1014,13 @@ mailpit:
 
 # ===== P2P SYNC: Cadence =====
 cadence:
-  # 0.6.0 soak (mono#2103 Fix 1 + infra#77 Fix 3): DB-owned updated_at
+  # 0.6.1 soak (mono#2103 Fix 1 + infra#77 Fix 3): DB-owned updated_at
   # triggers + (updated_at, id) keyset index installed by ensure_sync_infra
   # at watcher boot (mono#2126), and fail-closed explicit allowlist — "*"
   # is now a boot error, unconfigured collections are dropped at the
-  # receive path (mono#2128). Watcher knobs default watcher_grace_ms=5000 /
+  # receive path (mono#2128); 0.6.1 adds the DDL advisory lock, symmetric
+  # receive-gate normalization and drops the boot-time backdated warn
+  # (mono#2132). Watcher knobs default watcher_grace_ms=5000 /
   # watcher_ensure_pg_ddl=true; override via CADENCE_WATCHER_GRACE_MS /
   # CADENCE_WATCHER_ENSURE_PG_DDL env if needed. Prod stays on 0.5.41
   # until 24h soak + the mono#2103 NULL-growth gate clear.
@@ -1026,7 +1028,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.6.0"
+    tag: "0.6.1"
     pullPolicy: Always
 
   # Phase 1a: per-collection watcher workers, throttled by the 0.5.25

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -414,6 +414,13 @@ hapihubNext:
     STORAGE_DOWNLOAD_URL_HOST: "https://hapihub-next.localfirsthealth.com"
 
   env:
+    # #2114 OOM stopgap: JSC sizes heap-growth heuristics off machine RAM, not
+    # the cgroup — under burst allocation the heap overshoots the container
+    # limit before a full GC runs. Force it to see 3GiB (limit is 4Gi; the
+    # remaining ~1GiB covers non-JSC memory: Buffers, in-pod Chromium/export
+    # workers — RUN_WORKERS=true here).
+    - name: BUN_JSC_forceRAMSize
+      value: "3221225472"
     - name: BETTER_AUTH_RATE_LIMIT_ENABLED
       value: "true"
     - name: BETTER_AUTH_RATE_LIMIT_WINDOW


### PR DESCRIPTION
Fixes from the first 0.6.0 boot — see mycurelabs/monobase-mycure#2132 for the full findings + proof trail. Restarts the 24h soak clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)