### PR TITLE
fix(hapihub-next): OOM stopgap — honest memory request + 4th replica (mono#2129)

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -355,12 +355,19 @@ hapihubNext:
   pruneExpiredSessions:
     enabled: true
 
-  replicaCount: 3
+  # 4th replica: OOM-kill stopgap for mono#2129/mono#2114 — kills continue at
+  # ~130/day (fan-out fix PRs not yet shipped), extra replica reduces the
+  # blast-radius of each kill during clinic peak hours.
+  replicaCount: 4
 
   resources:
     requests:
       cpu: 500m
-      memory: 1Gi
+      # 2560Mi matches the real working set (pods cycle 0.5→3.8Gi before each
+      # OOM kill). At 1Gi the scheduler packed a replica onto the node hosting
+      # postgresql-primary (production-3cl5of, observed 105% CPU / 98% mem);
+      # honest requests push replicas onto the idle production nodes instead.
+      memory: 2560Mi
     limits:
       cpu: "2"
       # 2Gi caused a persistent OOMKill loop (exit 137, ~90 restarts/replica)


### PR DESCRIPTION
## Summary

Infra stopgap for **mycurelabs/monobase-mycure#2129** (umbrella clinic slowness reports) / **mycurelabs/monobase-mycure#2114** (hapihub-next OOM crashloop).

`hapihub-next` prod has been OOM-crashlooping since **Jul 1** — ~130 OOMKills/day, kill rate tracking PH clinic peak hours (today: 18 kills in the exact 10–11 AM PH window clinics reported). Root cause is the mono#2114 `app.request()` fan-out; fix PRs (mono#2119/#2121/#2127) are in progress but not shipped. Each kill drops all in-flight requests on the pod; nginx retries mask it as *slowness*, which is what clinics feel.

## Changes (`values/deployments/mycure-production.yaml`, hapihubNext)

| Setting | Before | After | Why |
|---|---|---|---|
| `resources.requests.memory` | 1Gi | 2560Mi | Pods actually cycle 0.5→3.8Gi before each kill. At 1Gi the scheduler packed a replica onto the node hosting `postgresql-primary-0` (`production-3cl5of`, observed **105% CPU / 98% mem**). Honest requests spread replicas to the idle production nodes (`3uz7ec`/`3uz7em` at 24%/40% mem). |
| `replicaCount` | 3 | 4 | Shrinks per-kill blast-radius during peak windows. |

Limit stays 4Gi (bumping it just delays each kill; the fan-out allocates until killed).

**Capacity**: 4 × 2560Mi = 10Gi requested; `production-3uz7ec`/`3uz7em` have ample request headroom (~13.7Gi allocatable each, currently 24%/40% used). Verified render: `helm template argocd/applications -f values/deployments/mycure-production.yaml` → `replicaCount: 4`, `memory: 2560Mi` land in the hapihub-next valuesObject.

## Not a fix

Kills continue until the mono#2114 fan-out PRs deploy — this only reduces blast-radius and gets hapihub-next off the PG-primary node. Follow-ups noted on mono#2129: `pg_stat_statements` on prod PG, anti-affinity vs postgresql-primary in the chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
