### PR TITLE
fix(hapihub-next): raise HPA maxReplicas 3→5 — replicaCount was a no-op (mono#2129)

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -355,10 +355,10 @@ hapihubNext:
   pruneExpiredSessions:
     enabled: true
 
-  # 4th replica: OOM-kill stopgap for mono#2129/mono#2114 — kills continue at
-  # ~130/day (fan-out fix PRs not yet shipped), extra replica reduces the
-  # blast-radius of each kill during clinic peak hours.
-  replicaCount: 4
+  # NOTE: replicaCount is ignored — autoscaling.enabled: true below means the
+  # HPA owns the replica count (chart omits spec.replicas). Scale via
+  # autoscaling.minReplicas/maxReplicas.
+  replicaCount: 3
 
   resources:
     requests:
@@ -460,8 +460,12 @@ hapihubNext:
 
   autoscaling:
     enabled: true
-    minReplicas: 1
-    maxReplicas: 3
+    minReplicas: 2
+    # maxReplicas 3 → 5: OOM-kill stopgap for mono#2129/mono#2114. HPA has been
+    # pinned at max (CPU ~92% vs 70% target) while pods OOM-crashloop ~130x/day;
+    # extra replicas shrink each kill's blast-radius during clinic peak hours
+    # until the fan-out fix PRs (mono#2119/#2121/#2127) ship.
+    maxReplicas: 5
 
   externalSecrets:
     enabled: true


### PR DESCRIPTION
Follow-up to #83. `hapihubNext.autoscaling.enabled: true` means the chart omits `spec.replicas` (HPA owns the count), so the `replicaCount: 4` bump in #83 never applied — the deployment stayed at 3, with the HPA pinned at max (`cpu: 92%/70%`) while pods OOM-crashloop (mycurelabs/monobase-mycure#2129 / mycurelabs/monobase-mycure#2114).

- `autoscaling.maxReplicas` 3 → 5 (HPA will scale up immediately given current CPU pressure)
- `autoscaling.minReplicas` 1 → 2 (avoid thin single-replica coverage while kills continue)
- `replicaCount` back to 3 with a note that it's HPA-owned

The memory-request change from #83 (1Gi → 2560Mi) applied correctly and is unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)