### PR TITLE
feat(hapihub-next): dedicated worker deployment, RUN_WORKERS off API pods (mono#2114)

### DIFF
--- a/argocd/applications/templates/hapihub-next-worker.yaml
+++ b/argocd/applications/templates/hapihub-next-worker.yaml
@@ -1,0 +1,69 @@
+{{- /*
+  Gated on BOTH hapihubNext.enabled and hapihubNextWorker.enabled — the
+  worker is a derivative of the hapihub-next release and meaningless
+  without it. `(default dict)` keeps nil-safe on deployments that omit
+  either block.
+*/ -}}
+{{- if and ((.Values.hapihubNext | default dict).enabled) ((.Values.hapihubNextWorker | default dict).enabled) }}
+# ArgoCD Application: HapiHub Next Worker (background jobs off the API pods)
+#
+# Third Helm release of the hapihub chart. Runs the SAME image/config as
+# hapihub-next but exists solely to consume pg-boss jobs (exports, email,
+# document ingestion, PDF conversion): RUN_WORKERS=true here and
+# RUN_WORKERS=false on the API release (mono#2114 — a single export/PDF
+# job landing on an API pod ballooned it to the memory limit; job memory
+# must not evict request-serving pods).
+#
+# Values = deep-merge of the hapihubNext block with the small
+# hapihubNextWorker override block, so image bumps and config changes to
+# hapihub-next flow to the worker automatically. Overrides disable all
+# traffic-facing extras (gateway/HTTPRoute, storageRoute, prune cronjob,
+# HPA) — the worker gets a Service and probes only.
+#
+# Sync wave 3, alongside the other hapihub releases.
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.global.namespace }}-hapihub-next-worker
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    path: charts/hapihub
+    repoURL: {{ .Values.argocd.repoURL }}
+    targetRevision: {{ .Values.argocd.targetRevision | default "main" }}
+    helm:
+      releaseName: hapihub-next-worker
+      valuesObject:
+        {{- $base := omit .Values.hapihubNext "mongodb" "minio" "valkey" "mailpit" }}
+        {{- $overrides := omit .Values.hapihubNextWorker "enabled" }}
+        {{- $merged := mergeOverwrite (deepCopy $base) $overrides }}
+        {{- toYaml $merged | nindent 8 }}
+        global: {{ .Values.global | toYaml | nindent 10 }}
+        minio: {{ mergeOverwrite (deepCopy .Values.minio) (.Values.hapihubNext.minio | default dict) | toYaml | nindent 10 }}
+        mongodb: {{ mergeOverwrite (deepCopy .Values.mongodb) (.Values.hapihubNext.mongodb | default dict) | toYaml | nindent 10 }}
+        valkey: {{ mergeOverwrite (deepCopy .Values.valkey) (.Values.hapihubNext.valkey | default dict) | toYaml | nindent 10 }}
+        mailpit: {{ mergeOverwrite (deepCopy .Values.mailpit) (.Values.hapihubNext.mailpit | default dict) | toYaml | nindent 10 }}
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .Values.global.namespace }}
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        maxDuration: 5m
+{{- end }}

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -419,6 +419,10 @@ hapihubNext:
     # the v10 host (EXTERNAL_ADDRESS, which is also Better Auth's baseURL and can't
     # change). Requires hapihub >= 11.20.32 (which wires storage.downloadURLHost).
     STORAGE_DOWNLOAD_URL_HOST: "https://hapihub-next.localfirsthealth.com"
+    # mono#2114: background jobs (exports, email, doc-ingestion, PDF/Chromium)
+    # moved to the hapihub-next-worker release below — a single export/PDF
+    # job landing on an API pod ballooned it toward the memory limit.
+    RUN_WORKERS: "false"
 
   env:
     # #2114 OOM stopgap: JSC sizes heap-growth heuristics off machine RAM, not
@@ -540,6 +544,38 @@ hapihubNext:
       database: hapihub
       username: postgres
       existingSecret: postgresql
+
+# hapihub-next-worker: background-job consumer for hapihub-next
+# (mono#2114). Deep-merged onto the hapihubNext block by the
+# hapihub-next-worker ArgoCD app template — image/config/secrets flow from
+# hapihubNext automatically; only the deltas live here.
+hapihubNextWorker:
+  enabled: true
+
+  replicaCount: 1
+
+  config:
+    RUN_WORKERS: "true"
+
+  # No external traffic: keep the Service (probes) but no routes.
+  gateway:
+    enabled: false
+    storageRoute:
+      enabled: false
+    snippetsPolicy:
+      enabled: false
+
+  # The API release owns the daily session-prune cronjob.
+  pruneExpiredSessions:
+    enabled: false
+
+  # Fixed single replica — job throughput does not need an HPA, and pg-boss
+  # handles multi-consumer anyway if this is ever raised.
+  autoscaling:
+    enabled: false
+
+  podDisruptionBudget:
+    enabled: false
 
 # ===== HEALTHCARE: Frontend Application =====
 mycure:


### PR DESCRIPTION
## Summary

Stacked on #81. Moves pg-boss background jobs (exports, email, document ingestion, PDF/Chromium conversion) off the request-serving hapihub-next pods.

**Why:** `RUN_WORKERS=true` on the API pods (verified live) means a single export or PDF job lands on one pod and balloons it toward the memory limit — the cleanest explanation for the "one pod at 92% while two sit idle" pattern in mono#2114. Job memory must not be able to evict request-serving pods.

## Design

- **New `hapihub-next-worker` ArgoCD app** — third Helm release of the existing hapihub chart. Its `valuesObject` **deep-merges the `hapihubNext` block with a small `hapihubNextWorker` override block**, so image bumps, config, env (incl. `BUN_JSC_forceRAMSize` from #81) and the 23 ExternalSecrets keys all flow from hapihubNext automatically — only the deltas live in the values file.
- **Worker overrides:** `RUN_WORKERS=true`, 1 replica, `gateway.enabled=false` (no HTTPRoute), `storageRoute.enabled=false`, no prune cronjob (API release keeps it), no HPA/PDB. Gets its own `hapihub-next-worker-secrets` ExternalSecret from the same remote keys.
- **API release:** `RUN_WORKERS: "false"` — pg-boss is DB-backed, so API pods keep *enqueueing* jobs; only consumption moves.

## Render verification

`helm template` of both layers:
- ArgoCD app renders with the merged valuesObject (worker `RUN_WORKERS=true` / API `false`, image tag `11.20.37` identical, 9 env entries incl. BUN_JSC, 23 secrets, CORS/STORAGE_DOWNLOAD_URL_HOST inherited)
- Worker chart release produces **exactly** ConfigMap + Deployment(1 replica) + ExternalSecret + Service + ServiceAccount — no HTTPRoute/CronJob/HPA (asserted)

## Rollout notes

- Needs a **root-app sync** after merge (child-app sync alone won't render the new template)
- Watch after deploy: `kubectl get pods -l app.kubernetes.io/instance=hapihub-next-worker`; trigger an export and confirm the job runs on the worker pod while API pods' `rss_mb` (mono#2119 logging) stays flat
- Rollback = set `hapihubNextWorker.enabled: false` + revert the API `RUN_WORKERS` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)