### PR TITLE
fix(cadence): preprod → 0.6.2 (background ensure_sync_infra)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -1020,7 +1020,9 @@ cadence:
   # is now a boot error, unconfigured collections are dropped at the
   # receive path (mono#2128); 0.6.1 adds the DDL advisory lock, symmetric
   # receive-gate normalization and drops the boot-time backdated warn
-  # (mono#2132). Watcher knobs default watcher_grace_ms=5000 /
+  # (mono#2132); 0.6.2 runs ensure_sync_infra in a background task with
+  # index-before-backfill so the poll deadline can't cancel DDL mid-run
+  # (mono#2172, PR #2195). Watcher knobs default watcher_grace_ms=5000 /
   # watcher_ensure_pg_ddl=true; override via CADENCE_WATCHER_GRACE_MS /
   # CADENCE_WATCHER_ENSURE_PG_DDL env if needed. Prod stays on 0.5.41
   # until 24h soak + the mono#2103 NULL-growth gate clear.
@@ -1028,7 +1030,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.6.1"
+    tag: "0.6.2"
     pullPolicy: Always
 
   # Phase 1a: per-collection watcher workers, throttled by the 0.5.25


### PR DESCRIPTION
mycurelabs/monobase-mycure#2195 — ensure_sync_infra runs in a background task (poll-deadline-immune), index built before backfill, advisory lock rescoped to the fast DDL. Fixes mycurelabs/monobase-mycure#2172. Prod follows after a clean preprod boot + canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)