### PR TITLE
fix(cadence): prod → 0.6.2 (background ensure_sync_infra)

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1296,7 +1296,10 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.6.1"
+    # 0.6.2: ensure_sync_infra runs in a background task (poll-deadline-
+    # immune), index-before-backfill, advisory lock rescoped to fast DDL —
+    # fixes the mono#2172 livelock hit during the 0.6.1 prod deploy.
+    tag: "0.6.2"
     pullPolicy: Always
 
   # Phase 1 fix: spawn one watcher task per collection so a slow


### PR DESCRIPTION
mycurelabs/monobase-mycure#2195, fixes mycurelabs/monobase-mycure#2172. Preprod boot + canary verified clean on 0.6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)