### PR TITLE
refactor(cadence): per-env cadenceConfig ownership (item 0.1)

### DIFF
--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -123,6 +123,12 @@ persistence:
   mountPath: /app/data
 
 # Cadence config file (mounted as /app/cadence.yml)
+#
+# OWNERSHIP (2026-07-06): the LIVE config is owned by each env's values file
+# (values/deployments/mycure-<env>.yaml → cadence.cadenceConfig). This block
+# is only a safe standalone baseline for chart-only installs and MUST remain
+# a strict subset of every env config (Helm deep-merges maps — a key present
+# here cannot be removed by an env override). Do not add collections here.
 cadenceConfig:
   # 2026-07-03 (monobase-infra#77): explicit ALLOWLIST — the "*" wildcard
   # auto-discovery is removed. Wildcard made every public.* table a synced

--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -1033,6 +1033,38 @@ cadence:
     tag: "0.6.2"
     pullPolicy: Always
 
+  # ── cadenceConfig: OWNED HERE (per-env), not in the chart ─────────────
+  # The chart's cadenceConfig is only a safe standalone baseline (the same
+  # 2 collections). Each env values file carries the COMPLETE block: Helm
+  # deep-merges maps, so a partial override cannot REMOVE a chart-default
+  # key — always edit the full block here. This is the wave/rollout control
+  # point for the full-config sync program (plan: cadence bidirectional
+  # full-config sync). Keep in lockstep with services/hapihub/cadence.yml
+  # in monobase-mycure (parity check: scripts/check-cadence-config.ts
+  # --against this file).
+  cadenceConfig:
+    collections:
+      accounts:
+        strategy: lww
+        scope_columns:
+          user: id
+      personal-details:
+        strategy: lww
+        scope_columns:
+          user: id
+          organization: facility
+    collectionsBlacklist:
+      - "--drizzle-migrations"
+      - "-migration-checkpoints"
+      - "activity-logs"
+      - "*-history"             # personal-details-history, medical-records-history, ...
+      - "*-history-archive-*"   # *_history_archive_YYYYMMDD rotated snapshots
+    priorities:
+      "*": 50
+      accounts: 200
+      personal-details: 180
+
+
   # Phase 1a: per-collection watcher workers, throttled by the 0.5.25
   # Semaphore cap (min(num_cpus*2, 16)) so the boot connection storm
   # that crashlooped this pod on 2026-06-23 can't recur. Preprod-only

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1302,6 +1302,38 @@ cadence:
     tag: "0.6.2"
     pullPolicy: Always
 
+  # ── cadenceConfig: OWNED HERE (per-env), not in the chart ─────────────
+  # The chart's cadenceConfig is only a safe standalone baseline (the same
+  # 2 collections). Each env values file carries the COMPLETE block: Helm
+  # deep-merges maps, so a partial override cannot REMOVE a chart-default
+  # key — always edit the full block here. This is the wave/rollout control
+  # point for the full-config sync program (plan: cadence bidirectional
+  # full-config sync). Keep in lockstep with services/hapihub/cadence.yml
+  # in monobase-mycure (parity check: scripts/check-cadence-config.ts
+  # --against this file).
+  cadenceConfig:
+    collections:
+      accounts:
+        strategy: lww
+        scope_columns:
+          user: id
+      personal-details:
+        strategy: lww
+        scope_columns:
+          user: id
+          organization: facility
+    collectionsBlacklist:
+      - "--drizzle-migrations"
+      - "-migration-checkpoints"
+      - "activity-logs"
+      - "*-history"             # personal-details-history, medical-records-history, ...
+      - "*-history-archive-*"   # *_history_archive_YYYYMMDD rotated snapshots
+    priorities:
+      "*": 50
+      accounts: 200
+      personal-details: 180
+
+
   # Phase 1 fix: spawn one watcher task per collection so a slow
   # baseline scan of any single table (e.g. analytics-daily-counts
   # at 763k rows + 60s deadline) doesn't trigger the 10-consecutive-


### PR DESCRIPTION
First hardening item of the cadence full-config bidirectional sync program. No rendered-output change — proof in commit message. Enables preprod-only full-config rehearsal while prod stays at the 2-collection allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)