### PR TITLE
chore(postgresql): prod pg_stat_statements + primary node reservation (mono#2129 follow-ups)

### DIFF
--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -990,15 +990,26 @@ postgresql:
       size: 400Gi
     resources:
       requests:
-        cpu: 250m
-        memory: 4Gi
+        # 2026-07-07 node-reservation bump (mono#2129 follow-up): the primary
+        # actually uses ~1.3 cores / 11.5Gi but requested only 250m/4Gi, so the
+        # scheduler saw a "mostly free" node and co-located app pods on it
+        # during the #2114 incident (node hit 105% CPU). Honest requests
+        # de-facto reserve the node (~13.7Gi allocatable) without taints.
+        cpu: 1000m
+        memory: 12Gi
       limits:
         cpu: 2000m
         memory: 12Gi  # bumped 8Gi->12Gi 2026-06-29: primary was at ~95% mem (7.6/8Gi), OOM-kill headroom
     # Perf tuning — replaces PG defaults (shared_buffers 128MB / work_mem 4MB)
     # for the 35GB DB; sized to the 8Gi pod limit. See node-separation issue
     # for the CPU-oversubscription follow-up. Applying restarts the primary.
+    #
+    # shared_preload_libraries: bitnami's default is 'pgaudit' — keep it and
+    # add pg_stat_statements (mono#2129 follow-up: query attribution was
+    # impossible during the incident). Requires the restart this block already
+    # implies; CREATE EXTENSION pg_stat_statements in the hapihub DB after.
     extendedConfiguration: |
+      shared_preload_libraries = 'pgaudit, pg_stat_statements'
       shared_buffers = 2GB
       effective_cache_size = 5GB
       work_mem = 16MB
@@ -1039,6 +1050,7 @@ postgresql:
     # 2026-06-25. Capped on the primary by max_slot_wal_keep_size=80GB so a dead
     # replica can't refill the primary disk.
     extendedConfiguration: |
+      shared_preload_libraries = 'pgaudit, pg_stat_statements'
       shared_buffers = 2GB
       effective_cache_size = 5GB
       work_mem = 16MB


### PR DESCRIPTION
## Summary

The two parked follow-ups from mycurelabs/monobase-mycure#2129, sharing one primary restart. **Do not merge outside a maintenance window** — the postgresql app auto-syncs and applying restarts both PG statefulsets (brief write outage on the primary while it restarts; hapihub retries/reconnects).

| Change | Why |
|---|---|
| `shared_preload_libraries = 'pgaudit, pg_stat_statements'` (primary + read replica, lockstep) | Query attribution was impossible during the incident — only `plpgsql` installed. `pgaudit` is the bitnami default and is preserved. Post-restart operator step: `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;` in the `hapihub` DB. |
| Primary `requests` 250m/4Gi → **1000m/12Gi** | The primary actually uses ~1.3 cores / 11.5Gi. The old requests made the scheduler see a "mostly free" node and co-locate app pods on it (node hit 105% CPU during the #2114 crashloop). Honest requests de-facto reserve the ~13.7Gi node — no taints needed. Limits unchanged (2000m/12Gi). |

Scheduled execution: tonight ~10:12 PM PH (merge → sync → verify preload + replication + CREATE EXTENSION → confirm hapihub healthy).

Render validated (`helm template argocd/applications -f values/deployments/mycure-production.yaml`): both extendedConfigurations carry the preload line; primary requests are 1000m/12Gi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)