### PR TITLE
feat(nocodb): move deployment from preprod to demo namespace

### DIFF
--- a/values/deployments/mycure-demo.yaml
+++ b/values/deployments/mycure-demo.yaml
@@ -137,9 +137,43 @@ mycure-dashboard:
     enabled: false
 
 # ===== INTERNAL TOOL: NocoDB (no-code DB UI for business, issue #2041) =====
-# Disabled in demo; enabled on preprod only for now.
+# Self-hosted, single replica, SQLite metadata on a PVC. An idempotent post-install
+# Job pre-adds the hapihub Postgres as a READ-ONLY data source
+# (NC_DISABLE_PG_DATA_REFLECTION=true stops NocoDB creating schemas in the connected
+# DB). Admin + RO creds come from GCP via ExternalSecret (keys mycure-production-nocodb-*
+# — demo reuses the production secretPrefix). Home for the tool as of issue #2097 (moved
+# off ephemeral preprod). Points at demo's own PG (schema present, data minimal).
 nocodb:
-  enabled: false
+  enabled: true
+
+  image:
+    repository: nocodb/nocodb
+    tag: "2026.06.2"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1536Mi
+
+  persistence:
+    size: 5Gi
+
+  gateway:
+    hostname: ""  # defaults to nocodb.demo.localfirsthealth.com
+    sectionName: https-demo-lfh
+
+  config:
+    NC_PUBLIC_URL: "https://nocodb.demo.localfirsthealth.com"
+    NC_DISABLE_PG_DATA_REFLECTION: "true"
+
+  bootstrap:
+    enabled: true
 
 # ===== HEALTHCARE: Frontend Application (mycureapp) =====
 mycure:

--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -138,46 +138,10 @@ mycure-dashboard:
     enabled: false
 
 # ===== INTERNAL TOOL: NocoDB (no-code DB UI for business, issue #2041) =====
-# Self-hosted, single replica, SQLite metadata on a PVC. Business connects the
-# hapihub Postgres as a READ-ONLY data source via the UI (NC_DISABLE_PG_DATA_
-# REFLECTION=true stops NocoDB creating schemas in the connected DB). No NC_DB /
-# NC_ADMIN_* / JWT secret here: first signup becomes super-admin and an
-# auto-generated JWT is fine for this ephemeral env. Prod adds those via an
-# ExternalSecret.
+# Moved to the demo namespace (issue #2097) — demo is the persistent sibling; preprod is
+# spun up per-rehearsal. Re-enable here only for preprod-specific rehearsals.
 nocodb:
-  enabled: true
-
-  image:
-    repository: nocodb/nocodb
-    tag: "2026.06.2"
-    pullPolicy: IfNotPresent
-
-  replicaCount: 1
-
-  resources:
-    requests:
-      cpu: 100m
-      memory: 512Mi
-    limits:
-      cpu: 1000m
-      memory: 1536Mi
-
-  persistence:
-    size: 5Gi
-
-  gateway:
-    hostname: ""  # defaults to nocodb.preprod.localfirsthealth.com
-    sectionName: https-preprod-lfh
-
-  config:
-    NC_PUBLIC_URL: "https://nocodb.preprod.localfirsthealth.com"
-    NC_DISABLE_PG_DATA_REFLECTION: "true"
-
-  # Pre-add the read-only hapihub data source on deploy (idempotent post-install
-  # Job). Admin + RO creds come from GCP via ExternalSecret (keys
-  # mycure-production-nocodb-* — preprod reuses the production secretPrefix).
-  bootstrap:
-    enabled: true
+  enabled: false
 
 # ===== HEALTHCARE: MyCure PXP (patient-facing web app) =====
 mycure-pxp:


### PR DESCRIPTION
Implements mycurelabs/monobase-mycure#2097 ("Point to demo namespace instead of preprod").

preprod is ephemeral (spun up per rehearsal, torn down with `kubectl delete ns`); demo is the persistent low-traffic sibling — the right home for a biz tool. Values-only swap, no chart changes:

- `mycure-demo.yaml`: enable the nocodb block (host `nocodb.demo.localfirsthealth.com`, `https-demo-lfh`, bootstrap on).
- `mycure-preprod.yaml`: back to a disabled stub → ArgoCD prunes the preprod nocodb resources.

Clean because demo shares everything NocoDB needs: `nodePool: staging`, `secretPrefix: mycure-production` (existing GCP `*-nocodb-*` keys resolve, no new secrets), in-cluster `postgresql`/`hapihub` DB, wildcard TLS. The bootstrap Job recreates the read-only role + admin + read-only source on demo's own PG (143-table schema, data minimal — confirmed acceptable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)