### PR TITLE
fix(cadence): preprod → 0.7.1 (boot scale fixes)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -1010,7 +1010,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.7.0"
+    tag: "0.7.1"
     pullPolicy: Always
 
   # ── cadenceConfig: OWNED HERE (per-env), not in the chart ─────────────


### PR DESCRIPTION
mycurelabs/monobase-mycure#2300 — lock_timeout, trigger fast-paths, ensure retry, zombie guard. Boot #3 = rehearsal start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)