### PR TITLE
fix(cadence): preprod → 0.7.3 (index-streamed baselines)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -1010,7 +1010,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.7.2"
+    tag: "0.7.3"
     pullPolicy: Always
 
   # ── cadenceConfig: OWNED HERE (per-env), not in the chart ─────────────


### PR DESCRIPTION
Boot #5; the 2h loaded soak starts on this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)