### PR TITLE
fix(cadence): preprod → 0.7.4 (resumable baselines)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -1010,7 +1010,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.7.3"
+    tag: "0.7.4"
     pullPolicy: Always
 
   # ── cadenceConfig: OWNED HERE (per-env), not in the chart ─────────────


### PR DESCRIPTION
Boot #6; loaded 2h soak starts here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)