### PR TITLE
feat(cadence): preprod + production hubs → 0.7.8

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -1010,7 +1010,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.7.6"
+    tag: "0.7.8"
     pullPolicy: Always
 
   # ── cadenceConfig: OWNED HERE (per-env), not in the chart ─────────────

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1336,7 +1336,7 @@ cadence:
     # 0.6.2: ensure_sync_infra runs in a background task (poll-deadline-
     # immune), index-before-backfill, advisory lock rescoped to fast DDL —
     # fixes the mono#2172 livelock hit during the 0.6.1 prod deploy.
-    tag: "0.7.6"
+    tag: "0.7.8"
     pullPolicy: Always
 
   # ── cadenceConfig: OWNED HERE (per-env), not in the chart ─────────────


### PR DESCRIPTION
Tag-only bump 0.7.6 → 0.7.8 on both hubs (config unchanged, 97 collections). Ships mycurelabs/monobase-mycure#2335: tombstone scope carriage (deletes finally propagate for scoped collections; `cadence_tombstones.old_row` migrated idempotently by `ensure_sync_infra` at boot), live created_at carriage, watermark hardening (rev-2 walk tokens — invisible to ≤0.7.7 boxes, wire-compat pinned to 0.7.5).

Merging deploys both (auto-sync). MDT re-test of the delete + created_at legs follows, then fleet HOLD lift (mycurelabs/monobase-mycure#2296).

🤖 Generated with [Claude Code](https://claude.com/claude-code)