### PR TITLE
fix(cadence): billing-legacy-invoices scope organization → facility (mono#2230)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -1097,7 +1097,7 @@ cadence:
       billing-legacy-invoices:
         strategy: lww
         scope_columns:
-          organization: organization
+          organization: facility
       billing-payment-methods:
         strategy: lww
         scope_columns:

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1418,7 +1418,7 @@ cadence:
       billing-legacy-invoices:
         strategy: lww
         scope_columns:
-          organization: organization
+          organization: facility
       billing-payment-methods:
         strategy: lww
         scope_columns:


### PR DESCRIPTION
One-value fix in both env cadenceConfigs: `billing_legacy_invoices` has no `organization` column (org ref = `facility`), so fail-closed scoping dropped 100% of this collection since the #2328 promotion (prod hub counters: pass=0/drop=44,330; 5,031 MDT invoice changes stranded). Boxes get the matching fix via maestroapp 1.5.28 (mycurelabs/monobase-mycure#2340).

🤖 Generated with [Claude Code](https://claude.com/claude-code)