### PR TITLE
feat(hapihub): 11.20.50 both envs — #2246 systemic fix + #2279 warehouse grants

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -188,7 +188,7 @@ hapihub:
 
   image:
     repository: ghcr.io/mycurelabs/hapihub
-    tag: "11.20.49" # #2304: phase-3 x-cache annotations (5 catalog services)
+    tag: "11.20.50" # #2246 _spreadData null-fallback + #2279 warehouse grants
     pullPolicy: IfNotPresent
 
   # Valkey response cache (mono#2231) — preprod is the pilot environment.

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -348,7 +348,7 @@ hapihubNext:
 
   image:
     repository: ghcr.io/mycurelabs/hapihub
-    tag: "11.20.49" # mono#2304 phase-3 catalog cache annotations; NEVER deploy 11.20.44 (stale binary)
+    tag: "11.20.50" # #2246 _spreadData null-fallback + #2279 warehouse grants; NEVER deploy 11.20.44 (stale binary)
     pullPolicy: IfNotPresent
 
   # Valkey response cache (mono#2231). Soaked on preprod 2026-07-07: 2h driven


### PR DESCRIPTION
Ships mycurelabs/monobase-mycure#2341: _spreadData null-fallback (legacy rows readable without one-off backfills) + warehouseEnabled sibling-org grant expansion for device sync tokens. Image 11.20.50 on GHCR (release run's auto-deploy step failed on app-token generation — deploying via IaC as usual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)