### PR TITLE
feat(cadence): hubs → 0.7.10 (mono#2342 box-upload stall fix)

### DIFF
--- a/values/deployments/mycure-preprod.yaml
+++ b/values/deployments/mycure-preprod.yaml
@@ -1010,7 +1010,7 @@ cadence:
 
   image:
     repository: ghcr.io/mycurelabs/cadence
-    tag: "0.7.9"
+    tag: "0.7.10"
     pullPolicy: Always
 
   # ── cadenceConfig: OWNED HERE (per-env), not in the chart ─────────────

--- a/values/deployments/mycure-production.yaml
+++ b/values/deployments/mycure-production.yaml
@@ -1336,7 +1336,7 @@ cadence:
     # 0.6.2: ensure_sync_infra runs in a background task (poll-deadline-
     # immune), index-before-backfill, advisory lock rescoped to fast DDL —
     # fixes the mono#2172 livelock hit during the 0.6.1 prod deploy.
-    tag: "0.7.9"
+    tag: "0.7.10"
     pullPolicy: Always
 
   # ── cadenceConfig: OWNED HERE (per-env), not in the chart ─────────────


### PR DESCRIPTION
Tag-only 0.7.9→0.7.10 both hubs. Hub now advertises max(in-memory, persisted) watermark in HelloAck — fixes the box→hub upload stall and the post-restart re-flood (mycurelabs/monobase-mycure#2344). Wire-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)